### PR TITLE
Argonne software mirror will no longer be available.

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -132,7 +132,7 @@ function findworkspace()
 {
   # default working directory, mirror and architecture
 
-  mirror=ftp://mirror.mcs.anl.gov/pub/cygwin
+  mirror=ftp://ftp.jaist.ac.jp/pub/cygwin
   arch="$(current_cygarch)"
   cache=/setup
   


### PR DESCRIPTION
Public access to the Argonne software mirror will no longer be available as of February 1, 2015.