### PR TITLE
verify digest with sha512

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ cyg-fast
 cyg-fast is a command-line installer for [Cygwin](http://cygwin.com/) which cooperates with Cygwin Setup and uses the same repository. The syntax is similar to apt-get. Usage examples:
 
 * "cyg-fast install &lt;package names&gt;" to install packages
+* "cyg-fast resume-install" to resume interrupted installing
 * "cyg-fast remove &lt;package names&gt;" to remove packages
 * "cyg-fast update" to update setup.ini
 * "cyg-fast show" to show installed packages

--- a/README.md
+++ b/README.md
@@ -16,10 +16,7 @@ The syntax is similar to apt-get. Usage examples:
 * "cyg-fast describe &lt;pattern(s)&gt;" to describe packages matching patterns
 * "cyg-fast packageof &lt;commands or files&gt;" to locate parent packages
 * "cyg-fast pathof &lt;cache|mirror|mirrordir|cache/mirrordir&gt;" to show path"
-* "cyg-fast key-add &lt;files&gt; ..." to add keys contained in &lt;files&gt;
-* "cyg-fast key-del &lt;keyids&gt; ..." to remove keys &lt;keyids&gt;
-* "cyg-fast key-list" to list keys
-* "cyg-fast key-finger" to list fingerprints
+* "cyg-fast build-deptree" to build dependency tree to make install/remove faster
 
 Requirements
 -----------
@@ -71,10 +68,17 @@ Of course you can also avoid signature check by using --no-verify or -X options.
 Public keys of cygwin and cygwinports are already registered to trusted keys of embeded.
 If you want to use some other public keys, please use ```key-*``` subcommands.
 
-
 ### Pre-resolving dependencies
 
 cyg-fast finds all depending packages before downloading and installing.
+
+### Generate dependency tree and check dependency on removing
+
+You can generate "dependency tree" using ```cyg-fast build-deptree```
+
+to make installing faster and enable dependency checking on removing.
+
+Generated dep-tree is in $cache/$mirrordir/$arch/deptree .
 
 ### Resume installation when downloading fails
 
@@ -128,5 +132,4 @@ Todo
 * Support multi mirrors: Cygwin setup can use multi mirrors. They are recorded at last-mirror section in '/etc/setup/setup.rc'. It's useful for using [Cygwinports](http://cygwinports.org/).
 * Support completion: Some other forks already supported it. For example, [Milly / apt-cyg](https://github.com/Milly/apt-cyg) under the cfg / apt-cyg fork, [ashumkin / apt-cyg](https://github.com/ashumkin/apt-cyg) and etc supported it.
 * Support upgrade: But maybe, busy resources can not be upgraded, and rebase problem will happen. Cygwin setup resolves by replacing them at next reboot.
-* Support dependency check for remove subcommand.
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-apt-cyg
+cyg-fast
 =======
 
-apt-cyg is a command-line installer for [Cygwin](http://cygwin.com/) which cooperates with Cygwin Setup and uses the same repository. The syntax is similar to apt-get. Usage examples:
+cyg-fast is a command-line installer for [Cygwin](http://cygwin.com/) which cooperates with Cygwin Setup and uses the same repository. The syntax is similar to apt-get. Usage examples:
 
-* "apt-cyg install &lt;package names&gt;" to install packages
-* "apt-cyg remove &lt;package names&gt;" to remove packages
-* "apt-cyg update" to update setup.ini
-* "apt-cyg show" to show installed packages
-* "apt-cyg find &lt;pattern(s)&gt;" to find packages matching patterns
-* "apt-cyg describe &lt;pattern(s)&gt;" to describe packages matching patterns
-* "apt-cyg packageof &lt;commands or files&gt;" to locate parent packages
-* "apt-cyg pathof &lt;cache|mirror|mirrordir|cache/mirrordir&gt;" to show path"
-* "apt-cyg key-add &lt;files&gt; ..." to add keys contained in &lt;files&gt;
-* "apt-cyg key-del &lt;keyids&gt; ..." to remove keys &lt;keyids&gt;
-* "apt-cyg key-list" to list keys
-* "apt-cyg key-finger" to list fingerprints
+* "cyg-fast install &lt;package names&gt;" to install packages
+* "cyg-fast remove &lt;package names&gt;" to remove packages
+* "cyg-fast update" to update setup.ini
+* "cyg-fast show" to show installed packages
+* "cyg-fast find &lt;pattern(s)&gt;" to find packages matching patterns
+* "cyg-fast describe &lt;pattern(s)&gt;" to describe packages matching patterns
+* "cyg-fast packageof &lt;commands or files&gt;" to locate parent packages
+* "cyg-fast pathof &lt;cache|mirror|mirrordir|cache/mirrordir&gt;" to show path"
+* "cyg-fast key-add &lt;files&gt; ..." to add keys contained in &lt;files&gt;
+* "cyg-fast key-del &lt;keyids&gt; ..." to remove keys &lt;keyids&gt;
+* "cyg-fast key-list" to list keys
+* "cyg-fast key-finger" to list fingerprints
 
 Requirements
 -----------
 
-apt-cyg requires the cygwin default environment and optional packages below.
+cyg-fast requires the cygwin default environment and optional packages below.
 
-* wget,ca-certificates,gnupg
+* aria2,wget,ca-certificates,gnupg
 
 In 32bit version of cygwin, wget requires an additional setting for ca-certificates package.
 Choose one of below settings.
@@ -46,25 +46,37 @@ But, as of 2014-01-17, perhaps ca-certificates package makes fail of certificati
 Quick start
 -----------
 
-apt-cyg is a simple script. Once you have a copy, make it executable:
+cyg-fast is a simple script. Once you have a copy, make it executable:
 
-    # chmod +x /bin/apt-cyg
+    # chmod +x /bin/cyg-fast
 
-Optionally place apt-cyg in a bin/ folder on your path.
+Optionally place cyg-fast in a bin/ folder on your path.
 
-Then use apt-cyg, for example:
+Then use cyg-fast, for example:
 
-    # apt-cyg install nano
+    # cyg-fast install nano
 
 New features
 ------------
+
+### Pre-resolving dependencies
+
+cyg-fast finds all depending packages before downloading and installing.
+
+### Parallel downloading with aria2
+
+Aria2 is an advances file downloading tool that allows you to download files with faster speed.
+
+cyg-fast provides multi-connection downloading using aria2.
+
+You can change the maximum number of connections with the ```--max-count``` option.
 
 ### True multi-architecture support
 
 Let think a case that you want to install the x86 package when you are working under the x86_64 environment.
 For example:
 
-    # apt-cyg --charch x86 install chere
+    # cyg-fast --charch x86 install chere
 
 As of 2013-10-26, chere package is provided for only the repository for x86.
 
@@ -73,7 +85,7 @@ Of course, you must install both environments of x86_64 and x86, beforehand.
 
 ### Signature check and key management by GnuPG
 
-The default action of apt-cyg has been changed to check signature for 'setup.ini'.
+The default action of cyg-fast has been changed to check signature for 'setup.ini'.
 Of course you can also avoid signature check by using --no-verify or -X options.
 Public keys of cygwin and cygwinports are already registered to trusted keys of embeded.
 If you want to use some other public keys, please use key-* subcommands.
@@ -108,6 +120,7 @@ Ex.) Merging to the GPL from the MIT is possible. But merging to the MIT from th
 * [buzain / apt-cyg](https://github.com/buzain/apt-cyg/network)
 * [wuyangnju / apt-cyg](https://github.com/wuyangnju/apt-cyg/network)
 * [takuya / apt-cyg](https://github.com/takuya/apt-cyg/network)
+* [lambdalice / cyg-fast](https://github.com/lambdalice/cyg-fast/network)
 
 Todo
 ------------

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ The syntax is similar to apt-get. Usage examples:
 * "cyg-fast describe &lt;pattern(s)&gt;" to describe packages matching patterns
 * "cyg-fast packageof &lt;commands or files&gt;" to locate parent packages
 * "cyg-fast pathof &lt;cache|mirror|mirrordir|cache/mirrordir&gt;" to show path"
-* "cyg-fast build-deptree" to build dependency tree to make install/remove faster
 
 Requirements
 -----------
@@ -65,13 +64,9 @@ Of course, you must install both environments of x86_64 and x86, beforehand.
 
 cyg-fast finds all depending packages before downloading and installing.
 
-### Generate dependency tree and check dependency on removing
+### Check dependency on removing
 
-You can generate "dependency tree" using ```cyg-fast build-deptree```
-
-to make installing faster and enable dependency checking on removing.
-
-Generated dep-tree is in $cache/$mirrordir/$arch/deptree .
+You can remove all packages depending on packages you want to remove.
 
 ### Resume installation when downloading fails
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,6 @@ As of 2013-10-26, chere package is provided for only the repository for x86.
 Remarks:
 Of course, you must install both environments of x86_64 and x86, beforehand.
 
-### Signature check and key management by GnuPG
-
-The default action of cyg-fast has been changed to check signature for 'setup.ini'.
-Of course you can also avoid signature check by using --no-verify or -X options.
-Public keys of cygwin and cygwinports are already registered to trusted keys of embeded.
-If you want to use some other public keys, please use ```key-*``` subcommands.
-
 ### Pre-resolving dependencies
 
 cyg-fast finds all depending packages before downloading and installing.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Requirements
 
 cyg-fast requires the cygwin default environment and optional packages below.
 
-* aria2, ca-certificates, gnupg
+* aria2
 
 Quick start
 -----------
@@ -118,11 +118,4 @@ Ex.) Merging to the GPL from the MIT is possible. But merging to the MIT from th
 * [buzain / apt-cyg](https://github.com/buzain/apt-cyg/network)
 * [wuyangnju / apt-cyg](https://github.com/wuyangnju/apt-cyg/network)
 * [takuya / apt-cyg](https://github.com/takuya/apt-cyg/network)
-
-Todo
-------------
-
-* Support multi mirrors: Cygwin setup can use multi mirrors. They are recorded at last-mirror section in '/etc/setup/setup.rc'. It's useful for using [Cygwinports](http://cygwinports.org/).
-* Support completion: Some other forks already supported it. For example, [Milly / apt-cyg](https://github.com/Milly/apt-cyg) under the cfg / apt-cyg fork, [ashumkin / apt-cyg](https://github.com/ashumkin/apt-cyg) and etc supported it.
-* Support upgrade: But maybe, busy resources can not be upgraded, and rebase problem will happen. Cygwin setup resolves by replacing them at next reboot.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You don't need to be annoy with an unstable internet connection...
 
 ### Force re-install packages
 
-You can reinstall a package by using ```cyg-fast --force install &lt;package&gt;```
+You can reinstall a package by using ```cyg-fast --force install <package>```
 
 ### Rapid mode
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 cyg-fast
 =======
 
-cyg-fast is a command-line installer for [Cygwin](http://cygwin.com/) which cooperates with Cygwin Setup and uses the same repository. The syntax is similar to apt-get. Usage examples:
+cyg-fast is an advanced version of apt-cyg, command-line installer for [Cygwin](http://cygwin.com/) which cooperates with Cygwin Setup and uses the same repository. The syntax is similar to apt-get. Usage examples:
+
+Supporting pre-resolving dependencies and parallel-downloading, cyg-fast works faster than apt-cyg.
 
 * "cyg-fast install &lt;package names&gt;" to install packages
 * "cyg-fast resume-install" to resume interrupted installing
@@ -22,27 +24,7 @@ Requirements
 
 cyg-fast requires the cygwin default environment and optional packages below.
 
-* aria2,wget,ca-certificates,gnupg
-
-In 32bit version of cygwin, wget requires an additional setting for ca-certificates package.
-Choose one of below settings.
-
-    # 1. Create symbolic link for the default ca-directory of wget. 
-    ln -s /usr/ssl /etc/
-    
-    # or
-    # 2. Set ca-directory paramete in '/etc/wgetrc'. 
-    echo "ca-directory = /usr/ssl/certs" >> /etc/wgetrc
-    
-    # or
-    # 3. Set ca-directory paramete in '~/.wgetrc'. 
-    echo "ca-directory = /usr/ssl/certs" >> ~/.wgetrc
-
-Remarks:
-Above additional settings for wget is not required for 64bit version of cygwin.
-But, as of 2014-01-17, perhaps ca-certificates package makes fail of certification in 64bit version of cygwin with Windows 8. See below:
-
-* Known Problem / [2014-01-17: ca-certificates package is not setup correct at x86_64 with Windows 8.](#2014-01-17-ca-certificates-package-is-not-setup-correct-at-x86_64-with-windows-8)
+* aria2, ca-certificates, gnupg
 
 Quick start
 -----------
@@ -55,20 +37,10 @@ Optionally place cyg-fast in a bin/ folder on your path.
 
 Then use cyg-fast, for example:
 
-    # cyg-fast install nano
+    # cyg-fast install vim
 
 New features
 ------------
-
-### Pre-resolving dependencies
-
-cyg-fast finds all depending packages before downloading and installing.
-
-### Resume installation when downloading fails
-
-Type ```cyg-fast resume-install``` to resume interrupted downloading.
-
-You don't need to be annoy with an unstable internet connection...
 
 ### Parallel downloading with aria2
 
@@ -95,10 +67,30 @@ Of course, you must install both environments of x86_64 and x86, beforehand.
 The default action of cyg-fast has been changed to check signature for 'setup.ini'.
 Of course you can also avoid signature check by using --no-verify or -X options.
 Public keys of cygwin and cygwinports are already registered to trusted keys of embeded.
-If you want to use some other public keys, please use key-* subcommands.
+If you want to use some other public keys, please use ```key-*``` subcommands.
 
-Contributing
-------------
+
+### Pre-resolving dependencies
+
+cyg-fast finds all depending packages before downloading and installing.
+
+### Resume installation when downloading fails
+
+Type ```cyg-fast resume-install``` to resume interrupted downloading.
+
+You don't need to be annoy with an unstable internet connection...
+
+### Force re-install packages
+
+You can reinstall a package by using ```cyg-fast --force install &lt;package&gt;```
+
+### Rapid mode
+
+If you are hurrying to install some packages, use ```--rapid``` to avoid wasting time 
+by updating setup.ini, checking certificates, checking signatures, checking MD5s, etc.
+
+Contributing (original apt-cyg)
+-------------------------------
 
 This project has been re-published on GitHub to make contributing easier. Feel free to fork and modify this script.
 
@@ -136,73 +128,3 @@ Todo
 * Support upgrade: But maybe, busy resources can not be upgraded, and rebase problem will happen. Cygwin setup resolves by replacing them at next reboot.
 * Support dependency check for remove subcommand.
 
-Known Problem
-------------
-### 2014-01-17: ca-certificates package is not setup correct at x86_64 with Windows 8.
-
-After clean installing with setup-x86_64, there are something wrong about ca-certificate package as below:
-
-    $ ls -lnG \
-         /cygdrive/c/cygwin/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt \
-         /cygdrive/c/cygwin64/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
-    -r--r--r-- 1 1001 314336 Jan 17 18:17 /cygdrive/c/cygwin/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
-    -rw-r--r-- 1 1001      0 Oct 16 12:35 /cygdrive/c/cygwin64/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
-    $ ls -lnG \
-         /cygdrive/c/cygwin/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
-         /cygdrive/c/cygwin64/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-    -r--r--r-- 1 1001 232342 Jan 17 18:17 /cygdrive/c/cygwin/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-    -rw-r--r-- 1 1001      0 Oct 16 12:35 /cygdrive/c/cygwin64/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-
-The x86 environment seems no problem except that need an additional setting for wget and ca-certificate. Hmm,,,    
-
-It seems that /usr/bin/update-ca-trust is failed at x86_64.
-
-It's ad hoc, but effective way to fix it, is to copy files from cygwin32 to cygwin64, as below:
-
-    cp -a /cygdrive/c/cygwin/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt \
-          /cygdrive/c/cygwin64/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
-    cp -a /cygdrive/c/cygwin/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
-          /cygdrive/c/cygwin64/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-
-This problem is fixed at 2014-01-24.
-version 0.18.7-1 of p11-kit, p11-kit-trust and libp11-kit0 did not work at the cygwin64 under the Windows 8.
-If you face the above problem, please upgrade these three packages from version 0.18.7-1 to version 0.18.7-2.
-
-For more details, see a thread of below:
-
-* Cygwin mailing list / cygwin / [Re: Is there someone who have a same problem ?](http://cygwin.com/ml/cygwin/2014-01/msg00368.html)
-
-### 2014-01-15: Signature check failed at cygwinports x86_64.
-Oops, setup.bz2 is newer than setup.bz2.sig.
-And it seems to be corrupted.
-
-    $ date
-    Wed Jan 15 01:30:19 JST 2014
-    $ w3m -dump ftp://ftp.cygwinports.org/pub/cygwinports/x86_64/
-    Index of ftp://ftp.cygwinports.org/pub/cygwinports/x86_64/
-    
-    [Upper Directory]
-    md5.sum. . . . . . . Jan 10 14:24    184
-    release/ . . . . . . Jan 10 18:00
-    setup.bz2. . . . . . Jan 10 13:59   579K
-    setup.bz2.sig. . . . Dec  6 11:28     72
-    setup.ini. . . . . . Dec  6 11:28  3.20M
-    setup.ini.sig. . . . Dec  6 11:28     72
-    
-    $ wget -q -O - ftp://ftp.cygwinports.org/pub/cygwinports/x86_64/setup.bz2 | bzip2 -tvv
-      (stdin):
-        [1: huff+mtf rt+rld]
-        [2: huff+mtf data integrity (CRC) error in data
-    
-    You can use the `bzip2recover' program to attempt to recover
-    data from undamaged sections of corrupted files.
-
-As of 2014-01-24, above problem is recovered at least.
-
-### FIXED: Check setup (cygcheck -c) can not detect .tar.xz packages
-At cygwin 1.7.25, cygcheck is hardcoded for .tar.gz and .tar.bz2.
-So check setup (cygcheck -c) can not detect .tar.xz packages.
-This bug was already fixed with [src/winsup/utils/dump_setup.cc#rev1.28](http://cygwin.com/cgi-bin/cvsweb.cgi/src/winsup/utils/dump_setup.cc?cvsroot=src#rev1.28).
-Please wait a release of cygwin 1.7.26.
-
-This Problem was fixed [cygwin 1.7.26](http://cygwin.com/ml/cygwin-announce/2013-11/msg00027.html) which released at 2013-11-29.

--- a/apt-cyg
+++ b/apt-cyg
@@ -291,7 +291,7 @@ function wget_return_case_md5sum ()
   esac
 }
 
-# Usage: check_md5sum label hash url file
+# Usage: wget_and_check_md5sum label hash url file
 function wget_and_check_md5sum ()
 {
   local LABEL="$1"

--- a/apt-cyg
+++ b/apt-cyg
@@ -728,7 +728,7 @@ function apt-cyg-install ()
     local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
     
     local warn=0
-    if [ -z "$requires" ]; then
+    if [ -n "$requires" ]; then
       echo Package $pkg requires the following packages, installing:
       echo $requires
       for package in $requires; do

--- a/apt-cyg
+++ b/apt-cyg
@@ -72,6 +72,7 @@ function usage()
   echo "  \"apt-cyg key-del <keyids> ...\" to remove keys <keyids>"
   echo "  \"apt-cyg key-list\" to list keys"
   echo "  \"apt-cyg key-finger\" to list fingerprints"
+  echo "  \"apt-cyg upgrade-self\" to upgrade apt-cyg"
   echo "Options:"
   echo "  --charch <arch>          : change archetecture"
   echo "  --use-setuprc            : set cache and mirror with /etc/setup/setup.rc"
@@ -439,6 +440,19 @@ function apt-cyg-pathof ()
     shift
   done
 }
+
+function apt-cyg-upgrade-self ()
+{
+  local basedir="$(dirname "$(readlink -f "$(which "$0")")")"
+  if [ ! -d "$basedir/.git" ]; then
+    echo -e "\e[31;1mError:\e[30;0m apt-get is not under the git version control."
+    exit 1
+  fi
+  pushd "$basedir"
+  git pull -v
+  popd
+}
+
 
 function apt-cyg-help ()
 {

--- a/cyg-fast
+++ b/cyg-fast
@@ -715,6 +715,7 @@ function cyg-fast-install ()
     fi
 
     # queue current package
+    local install="$(awk '/^install: / { print $2; exit }' "release/$pkg/desc")"
     echo "$mirror/$install" >> /tmp/cyg-fast-downloads
     echo "  dir=release/$pkg" >> /tmp/cyg-fast-downloads
     echo $pkg >> /tmp/cyg-fast-packages
@@ -736,9 +737,6 @@ function cyg-fast-install ()
     if [ $warn -ne 0 ]; then
       echo "Warning: some required packages do not install, continuing"
     fi
-
-    # pick the latest version, which comes first
-    local install="$(awk '/^install: / { print $2; exit }' "release/$pkg/desc")"
 
     if [ -z "$install" ]; then
       echo "Could not find \"install\" in package description: obsolete package?"

--- a/cyg-fast
+++ b/cyg-fast
@@ -89,7 +89,7 @@ function usage()
   echo "  --file, -f <file>        : read package names from file"
   echo "  --noupdate, -u           : don't update setup.ini from mirror"
   echo "  --ipv4, -4               : wget prefer ipv4"
-  echo "  --max-count, -c <count>  : maximum number of connections"
+  echo "  --max-count, -m <count>  : maximum number of connections"
   echo "  --help"
   echo "  --version"
 }
@@ -545,7 +545,7 @@ while [ $# -gt 0 ]; do
       shift
     ;;
 
-    --max-count|-c)
+    --max-count|-m)
       maxcount=$2
     ;;
 

--- a/cyg-fast
+++ b/cyg-fast
@@ -135,10 +135,9 @@ function findworkspace()
   mirror="${mirror%/}"
   mirrordir="$(mirror_to_mirrordir "$mirror/")"
 
-  if [ $checkdep -ne 1 ]; then
-    echo Working directory is $cache
-    echo Mirror is $mirror
-  fi
+  echo Working directory is $cache
+  echo Mirror is $mirror
+  
   mkdir -p "$cache/$mirrordir/$arch"
   cd "$cache/$mirrordir/$arch"
   
@@ -469,7 +468,6 @@ function cyg-fast-help ()
 
 noscripts=0
 noupdate=0
-checkdep=0
 OPT_FILES=()
 SUBCOMMAND=""
 ignore_case=""
@@ -480,7 +478,6 @@ YES_TO_ALL=false
 maxcount=5
 INITIAL_ARGS=( "$@" )
 ARGS=()
-
 while [ $# -gt 0 ]; do
   case "$1" in
 
@@ -544,11 +541,6 @@ while [ $# -gt 0 ]; do
 
     --noupdate|-u)
       noupdate=1
-      shift
-    ;;
-
-    --checkdep)
-      checkdep=1
       shift
     ;;
 
@@ -689,21 +681,37 @@ function cyg-fast-install ()
     checkpackages "$@"
     findworkspace
     getsetup
-
-    [ $checkdep -ne 0 ] || echo -n "Resolving dependencies..."
-
+    
     for pkg do
-      echo -n "."
       local already="$(grep -c "^$pkg " /etc/setup/installed.db)"
       if [ $already -ge 1 ] && [ -z $force ]; then
-        echo; echo Package $pkg is already installed, skipping
+        echo Package $pkg is already installed, skipping
         continue
       fi
+      CURRENT="${CURRENT[@]} $pkg"
+    done
+
+    echo -n "Resolving dependencies..."
+
+    resolve_deps
+
+    RESUME_INSTALL=0
+    cyg-fast-resume-install
+}
+
+function resolve_deps()
+{
+    echo -n "."
+    pkgs=${CURRENT[@]}
+    CURRENT=""
+    hasdeps=0
+    
+    for pkg in $pkgs; do
 
       # look for package and save desc file
-
+ 
       mkdir -p "release/$pkg"
-      awk > "release/$pkg/desc" -v package="$pkg" \
+      awk > "release/$pkg/desc" -v package=`echo $pkg` \
         'BEGIN{RS="\n\n@ "; FS="\n"} {if ($1 == package) {desc = $0; px++}} \
          END {if (px == 1 && desc != "") print desc; else print "Package not found"}' \
          setup.ini
@@ -725,19 +733,20 @@ function cyg-fast-install ()
 
       local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
       local warn=0
+      
       if [ -n "$requires" ]; then
         for package in $requires; do
           local already="$(grep -c "^$package " /etc/setup/installed.db)" 
           local installing="$( grep -c "^$package" /tmp/cyg-fast-packages)"
           if [ $already = 0 ] && [ $installing = 0 ] ; then
-            $cyg_fast -r --checkdep install $package
+            hasdeps=1
+            CURRENT=( ${CURRENT[@]} $package )
             if [ $? -ne 0 ]; then warn=1; fi
           fi
         done
       fi
-      if [ $warn -ne 0 ]; then
-        echo "Warning: some required packages do not install, continuing"
-      fi
+
+      [ $warn = 0 ] || echo "Warning: some required packages do not install, continuing"
 
       if [ -z "$install" ]; then
         echo "Could not find \"install\" in package description: obsolete package?"
@@ -745,14 +754,9 @@ function cyg-fast-install ()
       fi
     done
     
-    # exit when recursively called
+    # tailcall
 
-    if [ $checkdep = 1 ]; then
-      exit 0
-    fi
-
-    RESUME_INSTALL=0
-    cyg-fast-resume-install
+    [ $hasdeps = 0 ] ||  resolve_deps;
 }
 
 function cyg-fast-resume-install()

--- a/cyg-fast
+++ b/cyg-fast
@@ -52,13 +52,13 @@ TAR="$(  which tar  2>/dev/null )"
 GAWK="$( which awk  2>/dev/null )"
 GPGV="$( which gpgv 2>/dev/null )"
 GPG="$(  which gpg  2>/dev/null )"
-WGET="$(  which wget 2>/dev/null )"
 ARIA2C="$(  which aria2c  2>/dev/null )"
-if [ -z "$ARIA2C" -o -z "$WGET" -o -z "$TAR" -o -z "$GAWK" ]; then
-  echo You must install aria2, wget, tar and gawk to use cyg-fast.
+if [ -z "$ARIA2C" -o -z "$TAR" -o -z "$GAWK" ]; then
+  echo You must install aria2, tar and gawk to use cyg-fast.
   exit 1
 fi
 
+ARIA2C=( "${ARIA2C[@]}" "--conditional-get" "--allow-overwrite" )
 function usage()
 {
   echo cyg-fast: Installs and removes Cygwin packages.
@@ -88,7 +88,6 @@ function usage()
   echo "  --cache, -c <dir>        : set cache"
   echo "  --file, -f <file>        : read package names from file"
   echo "  --noupdate, -u           : don't update setup.ini from mirror"
-  echo "  --ipv4, -4               : wget prefer ipv4"
   echo "  --rapid, -r              : -X, --no-check-certificate, -u, skip checking MD5"
   echo "  --max-connections <num>  : maximum number of connections"
   echo "  --help"
@@ -149,10 +148,10 @@ function findworkspace()
 
 function download_and_verify ()
 {
-  "${WGET[@]}" -N "$1" || return 1
+  "${ARIA2C[@]}" "$1" || return 1
   [ -e "${1##*/}" ] || return 1
   if [ -z "$no_verify" ]; then
-    "${WGET[@]}" -N "${1}.sig" || return 1
+    "${ARIA2C[@]}" "${1}.sig" || return 1
     [ -e "${1##*/}.sig" ] && verify_signatures "${1##*/}.sig" || { rm -f "${1##*/}" "${1##*/}.sig"; return 1; }
   fi
   return
@@ -290,7 +289,7 @@ function wget_return_case_md5sum ()
     1) echo "$LABEL: FAILED: Could not download $URL."; return 1 ;;
     5) echo "$LABEL: WARNING: The SSL certificate is invalid $URL."
        ask_user "Continue regardless of invalid SSL certificate?" || return 1
-       "${WGET[@]}" --no-check-certificate "$URL" -O "$FILE"
+       "${ARIA2C[@]}" "$URL" -o "$FILE"
        return 0
     ;;
     8) echo "$LABEL: FAILED: 404 Not Found $URL." return 1 ;;
@@ -306,7 +305,7 @@ function wget_and_check_md5sum ()
   local MD5="$2"
   local URL="$3"
   local FILE="$4"
-  "${WGET[@]}" "$URL" -O "$FILE"
+  "${ARIA2C[@]}" `[ -n $no_check_cert ] || echo "--check-certificate"` "$URL" -o "$FILE"
   wget_return_case_md5sum "$?" || return 1
   if ! { echo "$MD5 *$FILE" | md5sum -c >& /dev/null; } then
     echo "$LABEL: FAILED: MD5 hash is not match."
@@ -517,7 +516,6 @@ while [ $# -gt 0 ]; do
     ;;
 
     --no-check-certificate)
-      WGET+=( "--no-check-certificate" )
       no_check_cert=1
       shift
     ;;
@@ -525,7 +523,7 @@ while [ $# -gt 0 ]; do
     --rapid|-r)
       no_verify=1
       noupdate=1
-      WGET+=( "--no-check-certificate" )
+      no_check_cert=1
       shift
     ;;
 
@@ -551,11 +549,6 @@ while [ $# -gt 0 ]; do
 
     --checkdep)
       checkdep=1
-      shift
-    ;;
-
-    --ipv4|-4)
-      WGET=( "${WGET[@]}" "--prefer-family=IPv4" )
       shift
     ;;
 
@@ -780,11 +773,10 @@ function cyg-fast-resume-install()
     # download all
     
     echo "Start downloading..."
-    aria2c --conditional-get \
-           --deferred-input \
-           `[ "$no_check_cert" = 1 ] || echo "--check-certificate"` \
-           --input-file /tmp/cyg-fast-downloads \
-           -x $maxcount || {
+    ${ARIA2C[@]} --deferred-input \
+                 `[ "$no_check_cert" = 1 ] || echo "--check-certificate"` \
+                 --input-file /tmp/cyg-fast-downloads \
+                 -x $maxcount || {
       echo "Interrupted: To resume installing, run \"cyg-fast resume-install\" ."
       exit 1
     }

--- a/cyg-fast
+++ b/cyg-fast
@@ -34,8 +34,6 @@ type aria2c tar gawk &> /dev/null || {
   exit 1
 }
 
-ARIA2C=( "aria2c" "--conditional-get" "--allow-overwrite" )
-
 function usage()
 {
   echo cyg-fast: Installs and removes Cygwin packages.
@@ -67,8 +65,6 @@ function usage()
   echo "  --version"
 }
 
-
-
 function version()
 {
   echo "cyg-fast version 0.57"
@@ -81,6 +77,14 @@ function current_cygarch ()
 {
   arch | sed -e 's/^i686$/x86/g'
 }
+
+if [ `current_cygarch` = "x86" ]; then
+  echo "Warning: x86 env detected: aria2 can't use --conditional-get, always download and overwrite"
+  ARIA2C=( "aria2c" "--allow-overwrite=true" )
+else
+  ARIA2C=( "aria2c" "--conditional-get" "--allow-overwrite" )
+fi
+
 
 function mirror_to_mirrordir ()
 {
@@ -544,6 +548,8 @@ function cyg-fast-install ()
 
 function resolve_deps()
 {
+    while true ; do
+
     echo -n "."
     pkgs=${CURRENT[@]}
     CURRENT=""
@@ -572,7 +578,7 @@ function resolve_deps()
           exit 1
         fi
       else
-        [ -f release/$pkg/desc ] || {
+        [ -f release/$pkg/desc -a `echo release/$pkg/desc` != "Package not found" ] || {
           echo; echo Package $pkg not found or ambiguous name, exiting
           rm /tmp/cyg-fast-* 2> /dev/null
           exit 1
@@ -592,6 +598,7 @@ function resolve_deps()
 
       local requires=""
 
+
       if [ -d deptree ]; then
         requires=`cat deptree/$pkg/requires`
       else
@@ -605,12 +612,9 @@ function resolve_deps()
           local already="$(grep -c "$package " /etc/setup/installed.db)" 
           if [ $already = 0 ]; then
             CURRENT=( ${CURRENT[@]} $package )
-            if [ $? -ne 0 ]; then warn=1; fi
           fi
         done
       fi
-
-      [ $warn = 0 ] || echo "Warning: some required packages do not install, continuing"
 
       if [ -z "$install" ]; then
         echo "Could not find \"install\" in package description: obsolete package?"
@@ -621,7 +625,8 @@ function resolve_deps()
     
     # tailcall
 
-    [ $hasdeps = 0 ] ||  resolve_deps;
+    [ $hasdeps = 0 ] && break;
+    done
 }
 
 function cyg-fast-resume-install()
@@ -643,9 +648,9 @@ function cyg-fast-resume-install()
     # download all
     
     echo "Start downloading..."
-    ${ARIA2C[@]} --deferred-input \
-                 --input-file /tmp/cyg-fast-downloads \
-                 -x $maxcount || {
+    ${ARIA2C[@]} --input-file /tmp/cyg-fast-downloads \
+                 `[ $(current_cygarch) = "x86" ] || echo "--deferred-input"` \
+                 -j $maxcount || {
       echo "Interrupted: To resume installing, run \"cyg-fast resume-install\" ."
       exit 1
     }

--- a/cyg-fast
+++ b/cyg-fast
@@ -54,6 +54,7 @@ function usage()
   echo "  --charch <arch>          : change archetecture"
   echo "  --use-setuprc            : set cache and mirror with /etc/setup/setup.rc"
   echo "  --ignore-case, -i        : ignore case distinctions for <patterns>"
+  echo "  --no-file-alloc, -n      : doesn't allocate file space before downloading"
   echo "  --force                  : force install/remove/fetch trustedkeys"
   echo "  --mirror, -m <url>       : set mirror"
   echo "  --cache, -c <dir>        : set cache"
@@ -87,14 +88,6 @@ function current_cygarch ()
 {
   arch | sed -e 's/^i686$/x86/g'
 }
-
-if [ `current_cygarch` = "x86" ]; then
-  warning "x86 env detected: aria2 can't use --conditional-get, always download and overwrite"
-  ARIA2C=( "aria2c" "--allow-overwrite=true" )
-else
-  ARIA2C=( "aria2c" "--conditional-get" "--allow-overwrite" )
-fi
-
 
 function mirror_to_mirrordir ()
 {
@@ -180,7 +173,7 @@ function setupini_download ()
     popd
     echo "Updated setup.ini"
     noupdate=1
-    ask_user "Would you like to generate dep-tree now?" && cyg-fast-build-deptree
+    echo Hint: Run cyg-fast build-deptree to enable dependency checking on removing.
     return
   done
   files_restore setup.ini setup.ini.sig setup.bz2 setup.bz2.sig
@@ -298,6 +291,7 @@ SUBCOMMAND=""
 ignore_case=""
 force=""
 YES_TO_ALL=false
+file_alloc=1
 maxcount=5
 INITIAL_ARGS=( "$@" )
 ARGS=()
@@ -350,6 +344,11 @@ while [ $# -gt 0 ]; do
       shift
     ;;
 
+    --no-file-alloc|-n)
+      file_alloc=0
+      shift
+    ;;
+
     --yes-to-all|-y)
       YES_TO_ALL=1
       shift
@@ -395,6 +394,19 @@ for file in "${OPT_FILES[@]}"; do
     warning "File $file not found, skipping"
   fi
 done
+
+# aria2 setup
+
+if [ `current_cygarch` = "x86" ]; then
+  warning "x86 env detected: aria2 can't use --conditional-get, always download and overwrite"
+  ARIA2C=( "aria2c" "--allow-overwrite=true" )
+else
+  ARIA2C=( "aria2c" "--conditional-get" "--allow-overwrite" )
+fi
+
+if [ $file_alloc = 0 ]; then
+  ARIA2C=( ${ARIA2C[@]} "--file-allocation=none" )
+fi
 
 
 
@@ -721,8 +733,7 @@ function cyg-fast-resume-install()
 function quit()
 {
     echo "Removing tmp files..."
-    rm /tmp/cyg-fast-downloads
-    rm /tmp/cyg-fast-packages
+    rm /tmp/cyg-fast-*
     echo Done.
     exit
 }

--- a/cyg-fast
+++ b/cyg-fast
@@ -26,6 +26,7 @@
 # 
 
 cyg_fast=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)/$(basename $0)
+
 TRUSTEDKEYS=( CYGWIN CYGWINPORTS );
 # ./cygwin.pub
 # ------------
@@ -145,7 +146,7 @@ function findworkspace()
   fetch_trustedkeys
 }
 
-function download_and_varify ()
+function download_and_verify ()
 {
   "${WGET[@]}" -N "$1" || return 1
   [ -e "${1##*/}" ] || return 1
@@ -193,8 +194,8 @@ function setupini_download ()
   files_backup setup.ini setup.ini.sig setup.bz2 setup.bz2.sig
   
   while true; do
-    download_and_varify "$mirror/$arch/setup.bz2" && { bunzip2 -k setup.bz2 && mv setup setup.ini || rm -f setup.bz2; }
-    download_and_varify "$mirror/$arch/setup.ini" || break
+    download_and_verify "$mirror/$arch/setup.bz2" && { bunzip2 -k setup.bz2 && mv setup setup.ini || rm -f setup.bz2; }
+    download_and_verify "$mirror/$arch/setup.ini" || break
     
     files_backup_clean setup.ini setup.ini.sig setup.bz2 setup.bz2.sig
     popd
@@ -693,88 +694,91 @@ function cyg-fast-install ()
     [ $checkdep -ne 0 ] || echo -n "Resolving dependencies..."
 
     for pkg do
-    echo -n "."
-    local already="$(grep -c "^$pkg " /etc/setup/installed.db)"
-    if [ $already -ge 1 ]; then
-      echo; echo Package $pkg is already installed, skipping
-      continue
-    fi
+      echo -n "."
+      local already="$(grep -c "^$pkg " /etc/setup/installed.db)"
+      if [ $already -ge 1 ]; then
+        echo; echo Package $pkg is already installed, skipping
+        continue
+      fi
 
-    # look for package and save desc file
+      # look for package and save desc file
 
-    mkdir -p "release/$pkg"
-    awk > "release/$pkg/desc" -v package="$pkg" \
-      'BEGIN{RS="\n\n@ "; FS="\n"} {if ($1 == package) {desc = $0; px++}} \
-       END {if (px == 1 && desc != "") print desc; else print "Package not found"}' \
-       setup.ini
-    local desc="$(< "release/$pkg/desc")"
-    if [ "$desc" = "Package not found" ]; then
-      echo; echo Package $pkg not found or ambiguous name, exiting
-      rm -r "release/$pkg"
-      exit 1
-    fi
+      mkdir -p "release/$pkg"
+      awk > "release/$pkg/desc" -v package="$pkg" \
+        'BEGIN{RS="\n\n@ "; FS="\n"} {if ($1 == package) {desc = $0; px++}} \
+         END {if (px == 1 && desc != "") print desc; else print "Package not found"}' \
+         setup.ini
+      local desc="$(< "release/$pkg/desc")"
+      if [ "$desc" = "Package not found" ]; then
+        echo; echo Package $pkg not found or ambiguous name, exiting
+        rm -r "release/$pkg"
+        exit 1
+      fi
 
-    # queue current package
-    local install="$(awk '/^install: / { print $2; exit }' "release/$pkg/desc")"
-    echo "$mirror/$install" >> /tmp/cyg-fast-downloads
-    echo "  dir=release/$pkg" >> /tmp/cyg-fast-downloads
-    echo $pkg >> /tmp/cyg-fast-packages
+      # queue current package
 
-    # resolve dependencies
+      local install="$(awk '/^install: / { print $2; exit }' "release/$pkg/desc")"
+      echo "$mirror/$install" >> /tmp/cyg-fast-downloads
+      echo "  dir=release/$pkg" >> /tmp/cyg-fast-downloads
+      echo $pkg >> /tmp/cyg-fast-packages
 
-    local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
-    local warn=0
-    if [ -n "$requires" ]; then
-      for package in $requires; do
-        local already="$(grep -c "^$package " /etc/setup/installed.db)" 
-        local installing="$( grep -c "^$package" /tmp/cyg-fast-packages)"
-        if [ $already = 0 ] && [ $installing = 0 ]; then
-          $cyg_fast -X -u --checkdep install $package
-          if [ $? -ne 0 ]; then warn=1; fi
-        fi
-      done
-    fi
-    if [ $warn -ne 0 ]; then
-      echo "Warning: some required packages do not install, continuing"
-    fi
+      # resolve dependencies
 
-    if [ -z "$install" ]; then
-      echo "Could not find \"install\" in package description: obsolete package?"
-      exit 1
-    fi
+      local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
+      local warn=0
+      if [ -n "$requires" ]; then
+        for package in $requires; do
+          local already="$(grep -c "^$package " /etc/setup/installed.db)" 
+          local installing="$( grep -c "^$package" /tmp/cyg-fast-packages)"
+          if [ $already = 0 ] && [ $installing = 0 ]; then
+            $cyg_fast -X -u --checkdep install $package
+            if [ $? -ne 0 ]; then warn=1; fi
+          fi
+        done
+      fi
+      if [ $warn -ne 0 ]; then
+        echo "Warning: some required packages do not install, continuing"
+      fi
+
+      if [ -z "$install" ]; then
+        echo "Could not find \"install\" in package description: obsolete package?"
+        exit 1
+      fi
     
-    # exit when recursively called
-    if [ $checkdep = 1 ]; then
-      exit 0
-    fi
+      # exit when recursively called
+
+      if [ $checkdep = 1 ]; then
+        exit 0
+      fi
 
     done
 
     [ -f "/tmp/cyg-fast-packages" ] || exit
-    echo ""
-    echo "Following packages will be installed:"
+    echo; echo "Following packages will be installed:"
     for p in $( cat /tmp/cyg-fast-packages ); do
       echo -n $p " "
     done
-    echo ""
-    read -p "Do you wish to continue? [y/N] " yn
+    echo; read -p "Do you wish to continue? [y/N] " yn
     case $yn in
       [Yy]* ) ;;
       * ) quit;;
     esac
 
     # download all
+
     echo "Start downloading..."
-    aria2c --conditional-get --deferred-input=true --input-file=/tmp/cyg-fast-downloads -x $maxcount
+    aria2c --conditional-get --deferred-input --input-file /tmp/cyg-fast-downloads -x $maxcount
 
     # unpack all
+
     for pkg in $( cat /tmp/cyg-fast-packages ); do
 
       install="$(awk '/^install: / { print $2; exit }' "release/$pkg/desc")"
       file="$(basename "$install")"
-      
       cd "release/$pkg"
+      
       # check the md5
+
       local digest="$(awk '/^install: / { print $4; exit }' "desc")"
       local digactual="$(md5sum $file | awk '{print $1}')"
       if [ "$digest" != "$digactual" ]; then

--- a/cyg-fast
+++ b/cyg-fast
@@ -26,6 +26,7 @@
 # 
 
 cyg_fast=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)/$(basename $0)
+cyg_fast_dir=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
 
 # this script requires some packages
 
@@ -57,8 +58,6 @@ function usage()
   echo "  --mirror, -m <url>       : set mirror"
   echo "  --cache, -c <dir>        : set cache"
   echo "  --file, -f <file>        : read package names from file"
-  echo "  --noupdate, -u           : don't update setup.ini from mirror"
-  echo "  --rapid, -r              : skip all optional functions"
   echo "  --max-connections <num>  : maximum number of connections"
   echo "  --yes-to-all, -y         : force yes on ask prompts"
   echo "  --help"
@@ -73,13 +72,24 @@ function version()
   echo "Copyright (c) 2005-9 Stephen Jungels.  Released under the GPL."
 }
 
+function warning()
+{
+  echo -e "\e[1;33mWarning:\e[30;0m $1"
+}
+
+function error()
+{
+  echo -e "\e[1;31mError:\e[30;0m $1" 1>&2
+}
+
+
 function current_cygarch ()
 {
   arch | sed -e 's/^i686$/x86/g'
 }
 
 if [ `current_cygarch` = "x86" ]; then
-  echo "Warning: x86 env detected: aria2 can't use --conditional-get, always download and overwrite"
+  warning "x86 env detected: aria2 can't use --conditional-get, always download and overwrite"
   ARIA2C=( "aria2c" "--allow-overwrite=true" )
 else
   ARIA2C=( "aria2c" "--conditional-get" "--allow-overwrite" )
@@ -157,7 +167,7 @@ function setupini_download ()
   local BASEDIR="$cache/$mirrordir/$arch"
   mkdir -p "$BASEDIR" || { echo -e "\e[31;1mError:\e[30;0m mkdir \"$BASEDIR\" failed."; exit 1; }
   
-  (( noscripts || noupdate )) && return
+  ( ((noupdate)) && [ -f $cache/$mirrordir/$arch/setup.ini ] ) && return
   
   pushd "$BASEDIR"
   files_backup setup.ini setup.ini.sig setup.bz2 setup.bz2.sig
@@ -175,7 +185,7 @@ function setupini_download ()
   done
   files_restore setup.ini setup.ini.sig setup.bz2 setup.bz2.sig
   popd
-  echo -e "\e[31;1mError:\e[30;0m updating setup.ini, reverting."
+  error "updating setup.ini, reverting."
   return 1
 }
 
@@ -201,7 +211,7 @@ function getrootdir ()
     x86_64)
       cygpath -u "$(< /proc/registry64/HKEY_LOCAL_MACHINE/SOFTWARE/Cygwin/setup/rootdir)" ;;
     *)
-      echo -e "\e[31;1mError:\e[30;0m unknown arch $1" >&2 ;;
+      error "unknown arch $1" ;;
   esac
 }
 
@@ -251,7 +261,7 @@ function cyg-fast-pathof ()
       cache/mirrordir)  echo "$cache/$mirrordir" ;;
       setup.ini)        echo "$cache/$mirrordir/$arch/setup.ini" ;;
       *)
-        echo -e "\e[31;1mError:\e[30;0m in function $FUNCNAME: unknown parameter: $1"
+        error "in function $FUNCNAME: unknown parameter: $1"
         exit 1
     esac
     shift
@@ -260,14 +270,18 @@ function cyg-fast-pathof ()
 
 function cyg-fast-upgrade-self ()
 {
-  local basedir="$(dirname "$(readlink -f "$(which "$0")")")"
-  if [ ! -d "$basedir/.git" ]; then
-    echo -e "\e[31;1mError:\e[30;0m apt-get is not under the git version control."
-    exit 1
-  fi
-  pushd "$basedir"
-  git pull -v
-  popd
+    if [ -d $cyg_fast_dir/.git ]; then
+        git pull -v
+    else
+        mv $cyg_fast $cyg_fast_dir/cyg-fast.bak
+        aria2c "https://raw.githubusercontent.com/lambdalice/cyg-fast/master/cyg-fast" --dir $cyg_fast_dir ||
+        {
+            error "while updating setup.ini"
+            exit 1
+        }
+    fi
+    chmod 775 $cyg_fast
+    echo "Updated cyg-fast"
 }
 
 
@@ -278,7 +292,6 @@ function cyg-fast-help ()
 
 # process options
 
-noscripts=0
 noupdate=0
 OPT_FILES=()
 SUBCOMMAND=""
@@ -318,9 +331,7 @@ while [ $# -gt 0 ]; do
     ;;
 
     --rapid|-r)
-      no_verify=1
-      noupdate=1
-      no_check_cert=1
+      warning "--rapid is obsolete, don't works"
       shift
     ;;
 
@@ -334,13 +345,8 @@ while [ $# -gt 0 ]; do
       shift ; shift
     ;;
 
-    --noscripts)
-      noscripts=1
-      shift
-    ;;
-
     --noupdate|-u)
-      noupdate=1
+      warning "--noupdate is obsolete, don't works"
       shift
     ;;
 
@@ -386,7 +392,7 @@ for file in "${OPT_FILES[@]}"; do
   if [ -f "$file" ]; then
     readarray -t -O ${#ARGS[@]} ARGS < "$file"
   else
-    echo File $file not found, skipping
+    warning "File $file not found, skipping"
   fi
 done
 
@@ -527,16 +533,23 @@ function cyg-fast-install ()
 
     checkpackages "$@"
     findworkspace
+    noupdate=1
     getsetup
+    echo
     
     for pkg do
       local already="$(grep -c "^$pkg " /etc/setup/installed.db)"
       if [ $already -ge 1 ] && [ -z $force ]; then
-        echo Package $pkg is already installed, skipping
+        warning "Package $pkg is already installed, skipping"
         continue
       fi
       CURRENT="${CURRENT[@]} $pkg"
     done
+
+    [ -f /tmp/cyg-fast-packages ] && {
+      warning "Interrupted resolving deps detected, ignoring."
+      rm /tmp/cyg-fast-*  
+    }
 
     echo -n "Resolving dependencies.."
     
@@ -554,7 +567,8 @@ function resolve_deps()
     pkgs=${CURRENT[@]}
     CURRENT=""
     hasdeps=0
-    
+
+        
     for pkg in $pkgs; do
 
       [ -f /tmp/cyg-fast-packages ] && {
@@ -572,14 +586,14 @@ function resolve_deps()
            setup.ini
         local desc="$(< "release/$pkg/desc")"
         if [ "$desc" = "Package not found" ]; then
-          echo; echo Package $pkg not found or ambiguous name, exiting
+          echo; error "Package $pkg not found or ambiguous name, exiting"
           rm -r "release/$pkg"
           rm /tmp/cyg-fast-* 2> /dev/null
           exit 1
         fi
       else
         [ -f release/$pkg/desc -a `echo release/$pkg/desc` != "Package not found" ] || {
-          echo; echo Package $pkg not found or ambiguous name, exiting
+          echo; error "Package $pkg not found or ambiguous name, exiting"
           rm /tmp/cyg-fast-* 2> /dev/null
           exit 1
         }
@@ -617,7 +631,7 @@ function resolve_deps()
       fi
 
       if [ -z "$install" ]; then
-        echo "Could not find \"install\" in package description: obsolete package?"
+        error "Could not find \"install\" in package description: obsolete package?"
         rm /tmp/cyg-fast-*
         exit 1
       fi
@@ -636,7 +650,7 @@ function cyg-fast-resume-install()
       echo "Nothing to install, exiting"
       exit 0
     fi
-
+      
     echo "Following packages will be installed:"
     for p in $( cat /tmp/cyg-fast-packages ); do
       echo -n $p " "
@@ -651,7 +665,7 @@ function cyg-fast-resume-install()
     ${ARIA2C[@]} --input-file /tmp/cyg-fast-downloads \
                  `[ $(current_cygarch) = "x86" ] || echo "--deferred-input"` \
                  -j $maxcount || {
-      echo "Interrupted: To resume installing, run \"cyg-fast resume-install\" ."
+      echo -e "\e[1;34mInterrupted:\e[0m To resume installing, run \"cyg-fast resume-install\" ."
       exit 1
     }
 
@@ -665,14 +679,14 @@ function cyg-fast-resume-install()
       
       # check the md5
 
-      if [ -z $rapid ]; then
+      while true; do
         local digest="$(awk '/^install: / { print $4; exit }' "desc")"
         local digactual="$(md5sum $file | awk '{print $1}')"
         if [ "$digest" != "$digactual" ]; then
-          echo MD5 sum did not match, exiting
-          exit 1
-        fi
-      fi
+          error "MD5 sum did not match, retry downloading..."
+          aria2c $mirror/$install
+        else break; fi
+      done
       
       echo "Unpacking: $pkg"
       tar > "/etc/setup/$pkg.lst" xvf "$file" -C /
@@ -692,7 +706,7 @@ function cyg-fast-resume-install()
     # run all postinstall scripts
     
     local pis="$(ls /etc/postinstall/*.sh 2>/dev/null | wc -l)"
-    if [ $pis -gt 0 -a $noscripts -ne 1 ]; then
+    if [ $pis -gt 0 ]; then
       echo Running postinstall scripts...
       for script in /etc/postinstall/*.sh; do
         $script
@@ -721,7 +735,9 @@ function cyg-fast-remove()
 
     findworkspace
     checkpackages "$@"
-    
+
+    echo
+
     CURRENT=""
     for pkg in $@; do
       if [ ! -e "/etc/setup/$pkg.lst.gz" -a -z "$force" ]; then
@@ -735,7 +751,7 @@ function cyg-fast-remove()
     [ $valid = 1 ] || exit -1
     [ -d deptree ] && remove-dep
 
-    echo; echo Warning: dep-tree not found. To check dependency on removing, run cyg-fast build-deptree.
+    echo; warning "dep-tree not found. To check dependency on removing, run cyg-fast build-deptree."
     echo "         " Only specified packages will be removed.
     ask_user "Do you wish to continue?" || exit
 
@@ -743,14 +759,14 @@ function cyg-fast-remove()
 
     local already="$(grep -c "^$pkg " /etc/setup/installed.db)"
     if [ $already -eq 0 ]; then
-      echo Package $pkg is not installed, skipping
+      warning "Package $pkg is not installed, skipping"
       continue
     fi
 
     local dontremove="cygwin coreutils gawk bzip2 tar xz aria2 bash"
     for req in $dontremove; do
       if [ "$pkg" = "$req" ]; then
-        echo cyg-fast cannot remove package $pkg, exiting
+        error "cyg-fast cannot remove package $pkg, exiting"
         exit 1
       fi
     done
@@ -796,7 +812,7 @@ function remove-dep()
         local dontremove="cygwin coreutils gawk bzip2 tar xz aria2 bash"
         for req in $dontremove; do
             if [ "$p" = "$req" ]; then
-            echo; echo cyg-fast cannot remove package $p, exiting
+            echo; error "cyg-fast cannot remove package $p, exiting"
             exit 1
           fi
         done
@@ -814,7 +830,7 @@ function remove-dep()
 
     echo; echo
 
-    [ $do_remove = 1 ] || { echo Nothing to remove, exiting; exit -1; }
+    [ $do_remove = 1 ] || { echo Nothing to remove, exiting; exit; }
 
     echo Following packages will be removed:
     echo ${REMOVE[@]}
@@ -847,7 +863,7 @@ function invoke_subcommand ()
     if type "$ACTION" >& /dev/null; then
       "$ACTION" "${ARGS[@]}"
     else
-      echo -e "\e[31;1mError:\e[30;0m unknown subcommand: $SUBCOMMAND"
+      error "unknown subcommand: $SUBCOMMAND"
       exit 1
     fi
 }

--- a/cyg-fast
+++ b/cyg-fast
@@ -63,6 +63,7 @@ function usage()
 {
   echo cyg-fast: Installs and removes Cygwin packages.
   echo "  \"cyg-fast install <package names>\" to install packages"
+  echo "  \"cyg-fast resume-install\" to resume interrupted installing"
   echo "  \"cyg-fast remove <package names>\" to remove packages"
   echo "  \"cyg-fast update\" to update setup.ini"
   echo "  \"cyg-fast show\" to show installed packages"
@@ -89,7 +90,7 @@ function usage()
   echo "  --file, -f <file>        : read package names from file"
   echo "  --noupdate, -u           : don't update setup.ini from mirror"
   echo "  --ipv4, -4               : wget prefer ipv4"
-  echo "  --max-count <count>      : maximum number of connections"
+  echo "  --max-connections <num>  : maximum number of connections"
   echo "  --help"
   echo "  --version"
 }
@@ -495,6 +496,11 @@ while [ $# -gt 0 ]; do
       shift
     ;;
 
+    --max-connections)
+      maxcount=$2
+      shift; shift
+    ;;
+
     --ignore-case|-i)
       ignore_case="$1"
       shift
@@ -543,10 +549,6 @@ while [ $# -gt 0 ]; do
     --checkdep)
       checkdep=1
       shift
-    ;;
-
-    --max-count)
-      maxcount=$2
     ;;
 
     --ipv4|-4)
@@ -681,6 +683,7 @@ function cyg-fast-packageof ()
 
 }
 
+RESUME_INSTALL=1
 
 function cyg-fast-install ()
 {
@@ -752,27 +755,40 @@ function cyg-fast-install ()
       fi
 
     done
+    RESUME_INSTALL=0
+    cyg-fast-resume-install
+}
 
-    [ -f "/tmp/cyg-fast-packages" ] || exit
+function cyg-fast-resume-install()
+{
+    if [ ! -f "/tmp/cyg-fast-packages" ]; then
+      echo "Nothing to install, exiting"
+      exit 0
+    fi
+
     echo; echo "Following packages will be installed:"
     for p in $( cat /tmp/cyg-fast-packages ); do
       echo -n $p " "
     done
-    echo; read -p "Do you wish to continue? [y/N] " yn
-    case $yn in
-      [Yy]* ) ;;
-      * ) quit;;
-    esac
+    echo; ask_user "Do you wish to continue?" || quit
+
+    [ $RESUME_INSTALL = 0 ] || findworkspace
 
     # download all
 
     echo "Start downloading..."
-    aria2c --conditional-get --deferred-input --input-file /tmp/cyg-fast-downloads -x $maxcount
+    aria2c --conditional-get \
+           --deferred-input \
+           --input-file /tmp/cyg-fast-downloads \
+           -x $maxcount || {
+      echo "Interrupted: To resume installing, run \"cyg-fast resume-install\" ."
+      exit 1
+    }
 
     # unpack all
 
     for pkg in $( cat /tmp/cyg-fast-packages ); do
-
+    
       install="$(awk '/^install: / { print $2; exit }' "release/$pkg/desc")"
       file="$(basename "$install")"
       cd "release/$pkg"
@@ -812,6 +828,7 @@ function cyg-fast-install ()
       done
     fi
     quit
+
 }
 
 
@@ -883,4 +900,3 @@ function invoke_subcommand ()
 }
 
 invoke_subcommand "$SUBCOMMAND" "${ARGS[@]}"
-

--- a/cyg-fast
+++ b/cyg-fast
@@ -81,8 +81,7 @@ function usage()
   echo "  --charch <arch>          : change archetecture"
   echo "  --use-setuprc            : set cache and mirror with /etc/setup/setup.rc"
   echo "  --ignore-case, -i        : ignore case distinctions for <patterns>"
-  echo "  --force-remove           : force remove"
-  echo "  --force-fetch-trustedkeys: force fetch trustedkeys"
+  echo "  --force                  : force install/remove/fetch trustedkeys"
   echo "  --no-verify, -X          : Don't verify setup.ini signatures"
   echo "  --no-check-certificate   : Don't validate the server's certificate"
   echo "  --mirror, -m <url>       : set mirror"
@@ -90,6 +89,7 @@ function usage()
   echo "  --file, -f <file>        : read package names from file"
   echo "  --noupdate, -u           : don't update setup.ini from mirror"
   echo "  --ipv4, -4               : wget prefer ipv4"
+  echo "  --rapid, -r              : -X, --no-check-certificate, -u, skip checking MD5"
   echo "  --max-connections <num>  : maximum number of connections"
   echo "  --help"
   echo "  --version"
@@ -328,7 +328,7 @@ function fetch_trustedkeys ()
     local URL="$(eval echo "\$${LABEL}_URL")"
     local URL_LATEST="$(eval echo "\$${LABEL}_URL_LATEST")"
     local CASE=""
-    if [ -z "$force_fetch_trustedkeys" ] && { "${GPG[@]}" --fingerprint --with-colons | grep -q "$FPR"; } then
+    if ( [ -z "$force" ] || [ -n $rapid ] ) && { "${GPG[@]}" --fingerprint --with-colons | grep -q "$FPR"; } then
       continue
     fi
     if [ -n "$URL" ]; then
@@ -474,8 +474,7 @@ checkdep=0
 OPT_FILES=()
 SUBCOMMAND=""
 ignore_case=""
-force_remove=""
-force_fetch_trustedkeys=""
+force=""
 no_verify=""
 YES_TO_ALL=false
 maxcount=5
@@ -506,13 +505,8 @@ while [ $# -gt 0 ]; do
       shift
     ;;
 
-    --force-remove)
-      force_remove=1
-      shift
-    ;;
-
-    --force-fetch-trustedkeys)
-      force_fetch_trustedkeys=1
+    --force)
+      force=1
       shift
     ;;
 
@@ -522,6 +516,13 @@ while [ $# -gt 0 ]; do
     ;;
 
     --no-check-certificate)
+      WGET+=( "--no-check-certificate" )
+      shift
+    ;;
+
+    --rapid|-r)
+      no_verify=1
+      noupdate=1
       WGET+=( "--no-check-certificate" )
       shift
     ;;
@@ -699,7 +700,7 @@ function cyg-fast-install ()
     for pkg do
       echo -n "."
       local already="$(grep -c "^$pkg " /etc/setup/installed.db)"
-      if [ $already -ge 1 ]; then
+      if [ $already -ge 1 ] && [ -z $force ]; then
         echo; echo Package $pkg is already installed, skipping
         continue
       fi
@@ -733,8 +734,8 @@ function cyg-fast-install ()
         for package in $requires; do
           local already="$(grep -c "^$package " /etc/setup/installed.db)" 
           local installing="$( grep -c "^$package" /tmp/cyg-fast-packages)"
-          if [ $already = 0 ] && [ $installing = 0 ]; then
-            $cyg_fast -X -u --checkdep install $package
+          if [ $already = 0 ] && [ $installing = 0 ] ; then
+            $cyg_fast -r --checkdep install $package
             if [ $? -ne 0 ]; then warn=1; fi
           fi
         done
@@ -747,14 +748,14 @@ function cyg-fast-install ()
         echo "Could not find \"install\" in package description: obsolete package?"
         exit 1
       fi
-    
-      # exit when recursively called
-
-      if [ $checkdep = 1 ]; then
-        exit 0
-      fi
-
     done
+    
+    # exit when recursively called
+
+    if [ $checkdep = 1 ]; then
+      exit 0
+    fi
+
     RESUME_INSTALL=0
     cyg-fast-resume-install
 }
@@ -795,11 +796,13 @@ function cyg-fast-resume-install()
       
       # check the md5
 
-      local digest="$(awk '/^install: / { print $4; exit }' "desc")"
-      local digactual="$(md5sum $file | awk '{print $1}')"
-      if [ "$digest" != "$digactual" ]; then
-        echo MD5 sum did not match, exiting
-        exit 1
+      if [ -z $rapid ]; then
+        local digest="$(awk '/^install: / { print $4; exit }' "desc")"
+        local digactual="$(md5sum $file | awk '{print $1}')"
+        if [ "$digest" != "$digactual" ]; then
+          echo MD5 sum did not match, exiting
+          exit 1
+        fi
       fi
       
       echo "Unpacking: $pkg"
@@ -863,7 +866,7 @@ function cyg-fast-remove()
       fi
     done
 
-    if [ ! -e "/etc/setup/$pkg.lst.gz" -a -z "$force_remove" ]; then
+    if [ ! -e "/etc/setup/$pkg.lst.gz" -a -z "$force" ]; then
       echo Package manifest missing, cannot remove $pkg.  Exiting
       exit 1
     fi
@@ -883,7 +886,6 @@ function cyg-fast-remove()
     echo Package $pkg removed
 
     done
-
 }
 
 function invoke_subcommand ()

--- a/cyg-fast
+++ b/cyg-fast
@@ -48,7 +48,6 @@ function usage()
   echo "  \"cyg-fast packageof <commands or files>\" to locate parent packages"
   echo "  \"cyg-fast pathof <cache|mirror|mirrordir|cache/mirrordir|setup.ini>\""
   echo "                                                          to show path"
-  echo "  \"cyg-fast build-deptree\" to build dependency tree to make install/remove faster"
   echo "  \"cyg-fast upgrade-self\" to upgrade cyg-fast"
   echo "Options:"
   echo "  --charch <arch>          : change archetecture"
@@ -173,7 +172,6 @@ function setupini_download ()
     popd
     echo "Updated setup.ini"
     noupdate=1
-    echo Hint: Run cyg-fast build-deptree to enable dependency checking on removing.
     return
   done
   files_restore setup.ini setup.ini.sig setup.bz2 setup.bz2.sig
@@ -489,53 +487,6 @@ function cyg-fast-packageof ()
 
 }
 
-function cyg-fast-build-deptree()
-{
-    findworkspace
-    getsetup
-    
-    echo Generating dependency tree...
-
-    [ -d deptree ] && rm deptree/*/neededby
-    mkdir -p deptree
-
-    PACKAGES=`awk 'BEGIN{ RS="\n\n@" ; FS="\n"; ORS="\n" } { print $1 "\n" }' setup.ini`
-
-    set -f; IFS='
-'
-    for pkg in $PACKAGES; do
-
-      [[ $pkg == "#"* ]] && continue
-      pkg=`echo $pkg | sed 's/ //g'`
-
-      mkdir -p deptree/$pkg
-
-      [ -f release/$pkg/desc  ] || {
-        mkdir -p "release/$pkg"
-        awk > "release/$pkg/desc" -v package=`echo $pkg` \
-          'BEGIN{RS="\n\n@ "; FS="\n"} {if ($1 == package) {desc = $0; px++}} \
-           END {if (px == 1 && desc != "") print desc; else print "Package not found"}' \
-           setup.ini
-      }
-
-      echo Generating: $pkg
-
-      local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
-      echo ${requires[@]} > deptree/$pkg/requires
-
-      unset IFS; set +f
-      for reqpkg in $requires; do
-        mkdir -p deptree/$reqpkg
-        echo -n $pkg " " >> deptree/$reqpkg/neededby
-      done
-      set -f; IFS='
-'
-    done
-
-    echo Done.
-    unset IFS; set +f
-}
-
 RESUME_INSTALL=1
 
 function cyg-fast-install ()
@@ -590,27 +541,18 @@ function resolve_deps()
 
       # look for package and save desc file
  
-      if [ ! -d deptree ]; then
-        mkdir -p "release/$pkg"
-        awk > "release/$pkg/desc" -v package=`echo $pkg` \
-          'BEGIN{RS="\n\n@ "; FS="\n"} {if ($1 == package) {desc = $0; px++}} \
-           END {if (px == 1 && desc != "") print desc; else print "Package not found"}' \
-           setup.ini
-        local desc="$(< "release/$pkg/desc")"
-        if [ "$desc" = "Package not found" ]; then
-          echo; error "Package $pkg not found or ambiguous name, exiting"
-          rm -r "release/$pkg"
-          rm /tmp/cyg-fast-* 2> /dev/null
-          exit 1
-        fi
-      else
-        [ -f release/$pkg/desc -a `echo release/$pkg/desc` != "Package not found" ] || {
-          echo; error "Package $pkg not found or ambiguous name, exiting"
-          rm /tmp/cyg-fast-* 2> /dev/null
-          exit 1
-        }
+      mkdir -p "release/$pkg"
+      awk > "release/$pkg/desc" -v package=`echo $pkg` \
+        'BEGIN{RS="\n\n@ "; FS="\n"} {if ($1 == package) {desc = $0; px++}} \
+        END {if (px == 1 && desc != "") print desc; else print "Package not found"}' \
+        setup.ini
+      local desc="$(< "release/$pkg/desc")"
+      if [ "$desc" = "Package not found" ]; then
+        echo; error "Package $pkg not found or ambiguous name, exiting"
+        rm -r "release/$pkg"
+        rm /tmp/cyg-fast-* 2> /dev/null
+        exit 1
       fi
-
      
       # queue current package
 
@@ -622,14 +564,7 @@ function resolve_deps()
       
       # resolve dependencies
 
-      local requires=""
-
-
-      if [ -d deptree ]; then
-        requires=`cat deptree/$pkg/requires`
-      else
-        requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
-      fi
+      local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
 
       local warn=0
       
@@ -760,44 +695,7 @@ function cyg-fast-remove()
     done
 
     [ $valid = 1 ] || exit -1
-    [ -d deptree ] && remove-dep
-
-    echo; warning "dep-tree not found. To check dependency on removing, run cyg-fast build-deptree."
-    echo "         " Only specified packages will be removed.
-    ask_user "Do you wish to continue?" || exit
-
-    for pkg in $CURRENT; do
-
-    local already="$(grep -c "^$pkg " /etc/setup/installed.db)"
-    if [ $already -eq 0 ]; then
-      warning "Package $pkg is not installed, skipping"
-      continue
-    fi
-
-    local dontremove="cygwin coreutils gawk bzip2 tar xz aria2 bash"
-    for req in $dontremove; do
-      if [ "$pkg" = "$req" ]; then
-        error "cyg-fast cannot remove package $pkg, exiting"
-        exit 1
-      fi
-    done
-
-    echo Removing $pkg
-
-    # run preremove scripts
-
-    if [ -e "/etc/preremove/$pkg.sh" ]; then
-      "/etc/preremove/$pkg.sh"
-    fi
-
-    gzip -cd "/etc/setup/$pkg.lst.gz" | awk '/[^\/]$/ {print "rm -f \"/" $0 "\""}' | sh
-    awk > /tmp/awk.$$ -v pkg="$pkg" '{if (pkg != $1) print $0}' /etc/setup/installed.db
-    rm -f "/etc/postinstall/$pkg.sh.done" "/etc/preremove/$pkg.sh" "/etc/setup/$pkg.lst.gz"
-    mv /etc/setup/installed.db /etc/setup/installed.db-save
-    mv /tmp/awk.$$ /etc/setup/installed.db
-    echo Package $pkg removed
-
-    done
+    remove-dep
 }
 
 function remove-dep()
@@ -831,8 +729,16 @@ function remove-dep()
         REMOVE=( ${REMOVE[@]} $p )
         do_remove=1
 
-        [ -f deptree/$p/neededby ] || continue
-        for npkg in `cat deptree/$p/neededby`; do
+        neededby=`awk '
+          /^@ / {
+            pn = $2
+          }
+          $0 ~ "^requires: .*"query {
+            print pn
+          }
+          ' query="$p" setup.ini`
+        
+        for npkg in $neededby; do
           CURRENT=( ${CURRENT[@]} $npkg )
         done
 

--- a/cyg-fast
+++ b/cyg-fast
@@ -694,6 +694,7 @@ function cyg-fast-install ()
     echo -n "Resolving dependencies..."
 
     resolve_deps
+    touch /tmp/cyg-fast-packages /tmp/cyg-fast-downloads
 
     RESUME_INSTALL=0
     cyg-fast-resume-install
@@ -707,6 +708,12 @@ function resolve_deps()
     hasdeps=0
     
     for pkg in $pkgs; do
+
+      local already="$(grep -c "$pkg " /etc/setup/installed.db)" 
+      local installing="$( grep -c "$pkg" /tmp/cyg-fast-packages)"
+      if [ $already = 1 ] || [ $installing = 1 ] ; then
+        continue;
+      fi
 
       # look for package and save desc file
  
@@ -728,7 +735,6 @@ function resolve_deps()
       echo "$mirror/$install" >> /tmp/cyg-fast-downloads
       echo "  dir=release/$pkg" >> /tmp/cyg-fast-downloads
       echo $pkg >> /tmp/cyg-fast-packages
-
       # resolve dependencies
 
       local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
@@ -736,9 +742,10 @@ function resolve_deps()
       
       if [ -n "$requires" ]; then
         for package in $requires; do
-          local already="$(grep -c "^$package " /etc/setup/installed.db)" 
-          local installing="$( grep -c "^$package" /tmp/cyg-fast-packages)"
-          if [ $already = 0 ] && [ $installing = 0 ] ; then
+          local already="$(grep -c "$package " /etc/setup/installed.db)" 
+          local installing="$( grep -c "$package" /tmp/cyg-fast-packages)"
+          local processing="$( echo ${CURRENT[@]} ${pkgs[@]} | grep -c "$package" )"
+          if [ $already = 0 ] && [ $installing = 0 ] && [ $processing = 0 ] ; then
             hasdeps=1
             CURRENT=( ${CURRENT[@]} $package )
             if [ $? -ne 0 ]; then warn=1; fi

--- a/cyg-fast
+++ b/cyg-fast
@@ -711,9 +711,7 @@ function resolve_deps()
     for pkg in $pkgs; do
 
       local installing="$( grep -c "$pkg" /tmp/cyg-fast-packages)"
-      if [ $installing = 1 ] ; then
-        continue;
-      fi
+      [ $installing = 0 ] || continue
 
       # look for package and save desc file
  

--- a/cyg-fast
+++ b/cyg-fast
@@ -49,6 +49,7 @@ function usage()
   echo "  \"cyg-fast packageof <commands or files>\" to locate parent packages"
   echo "  \"cyg-fast pathof <cache|mirror|mirrordir|cache/mirrordir|setup.ini>\""
   echo "                                                          to show path"
+  echo "  \"cyg-fast build-deptree\" to build dependency tree to make install/remove faster"
   echo "  \"cyg-fast upgrade-self\" to upgrade cyg-fast"
   echo "Options:"
   echo "  --charch <arch>          : change archetecture"
@@ -164,6 +165,8 @@ function setupini_download ()
     files_backup_clean setup.ini setup.ini.sig setup.bz2 setup.bz2.sig
     popd
     echo "Updated setup.ini"
+    noupdate=1
+    ask_user "Would you like to generate dep-tree now?" && cyg-fast-build-deptree
     return
   done
   files_restore setup.ini setup.ini.sig setup.bz2 setup.bz2.sig
@@ -464,6 +467,53 @@ function cyg-fast-packageof ()
 
 }
 
+function cyg-fast-build-deptree()
+{
+    findworkspace
+    getsetup
+    
+    echo Generating dependency tree...
+
+    [ -d deptree ] && rm deptree/*/neededby
+    mkdir -p deptree
+
+    PACKAGES=`awk 'BEGIN{ RS="\n\n@" ; FS="\n"; ORS="\n" } { print $1 "\n" }' setup.ini`
+
+    set -f; IFS='
+'
+    for pkg in $PACKAGES; do
+
+      [[ $pkg == "#"* ]] && continue
+      pkg=`echo $pkg | sed 's/ //g'`
+
+      mkdir -p deptree/$pkg
+
+      [ -f release/$pkg/desc  ] || {
+        mkdir -p "release/$pkg"
+        awk > "release/$pkg/desc" -v package=`echo $pkg` \
+          'BEGIN{RS="\n\n@ "; FS="\n"} {if ($1 == package) {desc = $0; px++}} \
+           END {if (px == 1 && desc != "") print desc; else print "Package not found"}' \
+           setup.ini
+      }
+
+      echo Generating: $pkg
+
+      local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
+      echo ${requires[@]} > deptree/$pkg/requires
+
+      unset IFS; set +f
+      for reqpkg in $requires; do
+        mkdir -p deptree/$reqpkg
+        echo -n $pkg " " >> deptree/$reqpkg/neededby
+      done
+      set -f; IFS='
+'
+    done
+
+    echo Done.
+    unset IFS; set +f
+}
+
 RESUME_INSTALL=1
 
 function cyg-fast-install ()
@@ -486,7 +536,6 @@ function cyg-fast-install ()
 
     echo -n "Resolving dependencies.."
     
-    touch /tmp/cyg-fast-packages /tmp/cyg-fast-downloads
     resolve_deps
         
     RESUME_INSTALL=0
@@ -502,39 +551,59 @@ function resolve_deps()
     
     for pkg in $pkgs; do
 
-      local installing="$( grep -c "$pkg" /tmp/cyg-fast-packages)"
-      [ $installing = 0 ] || continue
+      [ -f /tmp/cyg-fast-packages ] && {
+        local installing="$( grep -c "$pkg" /tmp/cyg-fast-packages)"
+        [ $installing = 0 ] || continue
+      }
 
       # look for package and save desc file
  
-      mkdir -p "release/$pkg"
-      awk > "release/$pkg/desc" -v package=`echo $pkg` \
-        'BEGIN{RS="\n\n@ "; FS="\n"} {if ($1 == package) {desc = $0; px++}} \
-         END {if (px == 1 && desc != "") print desc; else print "Package not found"}' \
-         setup.ini
-      local desc="$(< "release/$pkg/desc")"
-      if [ "$desc" = "Package not found" ]; then
-        echo; echo Package $pkg not found or ambiguous name, exiting
-        rm -r "release/$pkg"
-        exit 1
+      if [ ! -d deptree ]; then
+        mkdir -p "release/$pkg"
+        awk > "release/$pkg/desc" -v package=`echo $pkg` \
+          'BEGIN{RS="\n\n@ "; FS="\n"} {if ($1 == package) {desc = $0; px++}} \
+           END {if (px == 1 && desc != "") print desc; else print "Package not found"}' \
+           setup.ini
+        local desc="$(< "release/$pkg/desc")"
+        if [ "$desc" = "Package not found" ]; then
+          echo; echo Package $pkg not found or ambiguous name, exiting
+          rm -r "release/$pkg"
+          rm /tmp/cyg-fast-* 2> /dev/null
+          exit 1
+        fi
+      else
+        [ -f release/$pkg/desc ] || {
+          echo; echo Package $pkg not found or ambiguous name, exiting
+          rm /tmp/cyg-fast-* 2> /dev/null
+          exit 1
+        }
       fi
 
+     
       # queue current package
 
       local install="$(awk '/^install: / { print $2; exit }' "release/$pkg/desc")"
       echo "$mirror/$install" >> /tmp/cyg-fast-downloads
       echo "  dir=release/$pkg" >> /tmp/cyg-fast-downloads
       echo $pkg >> /tmp/cyg-fast-packages
+      hasdeps=1
+      
       # resolve dependencies
 
-      local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
+      local requires=""
+
+      if [ -d deptree ]; then
+        requires=`cat deptree/$pkg/requires`
+      else
+        requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
+      fi
+
       local warn=0
       
       if [ -n "$requires" ]; then
         for package in $requires; do
           local already="$(grep -c "$package " /etc/setup/installed.db)" 
           if [ $already = 0 ]; then
-            hasdeps=1
             CURRENT=( ${CURRENT[@]} $package )
             if [ $? -ne 0 ]; then warn=1; fi
           fi
@@ -545,6 +614,7 @@ function resolve_deps()
 
       if [ -z "$install" ]; then
         echo "Could not find \"install\" in package description: obsolete package?"
+        rm /tmp/cyg-fast-*
         exit 1
       fi
     done
@@ -556,12 +626,13 @@ function resolve_deps()
 
 function cyg-fast-resume-install()
 {
+    echo; echo
     if [ ! -f "/tmp/cyg-fast-packages" ]; then
       echo "Nothing to install, exiting"
       exit 0
     fi
 
-    echo; echo "Following packages will be installed:"
+    echo "Following packages will be installed:"
     for p in $( cat /tmp/cyg-fast-packages ); do
       echo -n $p " "
     done
@@ -641,9 +712,29 @@ function cyg-fast-remove()
 {
     local pkg
     local req
+    valid=0
 
+    findworkspace
     checkpackages "$@"
-    for pkg do
+    
+    CURRENT=""
+    for pkg in $@; do
+      if [ ! -e "/etc/setup/$pkg.lst.gz" -a -z "$force" ]; then
+        echo Package manifest missing, cannot remove $pkg.
+        continue
+      fi
+      valid=1
+      CURRENT=( ${CURRENT[@]} $pkg )
+    done
+
+    [ $valid = 1 ] || exit -1
+    [ -d deptree ] && remove-dep
+
+    echo; echo Warning: dep-tree not found. To check dependency on removing, run cyg-fast build-deptree.
+    echo "         " Only specified packages will be removed.
+    ask_user "Do you wish to continue?" || exit
+
+    for pkg in $CURRENT; do
 
     local already="$(grep -c "^$pkg " /etc/setup/installed.db)"
     if [ $already -eq 0 ]; then
@@ -659,10 +750,6 @@ function cyg-fast-remove()
       fi
     done
 
-    if [ ! -e "/etc/setup/$pkg.lst.gz" -a -z "$force" ]; then
-      echo Package manifest missing, cannot remove $pkg.  Exiting
-      exit 1
-    fi
     echo Removing $pkg
 
     # run preremove scripts
@@ -679,6 +766,72 @@ function cyg-fast-remove()
     echo Package $pkg removed
 
     done
+}
+
+function remove-dep()
+{
+    local pkg
+    REMOVE=""
+    do_remove=0
+
+    echo -n Resolving dependencies...
+
+    until [ -z $CURRENT ]; do
+
+      echo -n .
+      pkgs=${CURRENT[@]}
+      CURRENT=""
+
+      for p in $pkgs; do
+
+        already="$(grep -c "^$p " /etc/setup/installed.db)"
+        removing=`echo ${REMOVE[@]} | grep -c $p`
+        ([ $already -gt 0 ] && [ $removing = 0 ]) || continue
+
+        local dontremove="cygwin coreutils gawk bzip2 tar xz aria2 bash"
+        for req in $dontremove; do
+            if [ "$p" = "$req" ]; then
+            echo; echo cyg-fast cannot remove package $p, exiting
+            exit 1
+          fi
+        done
+      
+        REMOVE=( ${REMOVE[@]} $p )
+        do_remove=1
+
+        [ -f deptree/$p/neededby ] || continue
+        for npkg in `cat deptree/$p/neededby`; do
+          CURRENT=( ${CURRENT[@]} $npkg )
+        done
+
+      done
+    done
+
+    echo; echo
+
+    [ $do_remove = 1 ] || { echo Nothing to remove, exiting; exit -1; }
+
+    echo Following packages will be removed:
+    echo ${REMOVE[@]}
+    ask_user "Do you wish to continue?" || exit
+    
+    for pkg in ${REMOVE[@]}; do
+
+      echo Removing: $pkg
+
+      if [ -e "/etc/preremove/$pkg.sh" ]; then
+        "/etc/preremove/$pkg.sh"
+      fi
+      
+      gzip -cd "/etc/setup/$pkg.lst.gz" | awk '/[^\/]$/ {print "rm -f \"/" $0 "\""}' | sh
+      awk > /tmp/awk.$$ -v pkg="$pkg" '{if (pkg != $1) print $0}' /etc/setup/installed.db
+      rm -f "/etc/postinstall/$pkg.sh.done" "/etc/preremove/$pkg.sh" "/etc/setup/$pkg.lst.gz"
+      mv /etc/setup/installed.db /etc/setup/installed.db-save
+      mv /tmp/awk.$$ /etc/setup/installed.db
+    
+    done
+    echo Done.
+    exit
 }
 
 function invoke_subcommand ()

--- a/cyg-fast
+++ b/cyg-fast
@@ -476,6 +476,7 @@ SUBCOMMAND=""
 ignore_case=""
 force=""
 no_verify=""
+no_check_cert=""
 YES_TO_ALL=false
 maxcount=5
 INITIAL_ARGS=( "$@" )
@@ -517,6 +518,7 @@ while [ $# -gt 0 ]; do
 
     --no-check-certificate)
       WGET+=( "--no-check-certificate" )
+      no_check_cert=1
       shift
     ;;
 
@@ -774,12 +776,13 @@ function cyg-fast-resume-install()
     echo; ask_user "Do you wish to continue?" || quit
 
     [ $RESUME_INSTALL = 0 ] || findworkspace
-
+    
     # download all
-
+    
     echo "Start downloading..."
     aria2c --conditional-get \
            --deferred-input \
+           `[ "$no_check_cert" = 1 ] || echo "--check-certificate"` \
            --input-file /tmp/cyg-fast-downloads \
            -x $maxcount || {
       echo "Interrupted: To resume installing, run \"cyg-fast resume-install\" ."

--- a/cyg-fast
+++ b/cyg-fast
@@ -238,7 +238,7 @@ function ask_user ()
   while true; do
     [ -n "$2" ] && { local pmt="$2"; local def=; }
     [ -n "$2" ] || { local pmt="y/n";local def=; }
-    $YES_TO_ALL && { local RPY=Y;local def=Y; }
+    [ $YES_TO_ALL = 1 ] && { local RPY=Y;local def=Y; }
     [ -z "$def" ] && { echo -ne "$1 ";read -p "[$pmt] " RPY; }
     [ -z "$RPY" ] && { local RPY=$def; }
     case "$RPY" in

--- a/cyg-fast
+++ b/cyg-fast
@@ -714,18 +714,23 @@ function cyg-fast-install ()
       exit 1
     fi
 
+    # queue current package
+    echo "$mirror/$install" >> /tmp/cyg-fast-downloads
+    echo "  dir=release/$pkg" >> /tmp/cyg-fast-downloads
+    echo $pkg >> /tmp/cyg-fast-packages
+
     # resolve dependencies
 
     local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
     local warn=0
     if [ -n "$requires" ]; then
       for package in $requires; do
-        local already="$(grep -c "^$package " /etc/setup/installed.db)"
-        if [ $already -ge 1 ]; then
-          continue
+        local already="$(grep -c "^$package " /etc/setup/installed.db)" 
+        local installing="$( grep -c "^$package" /tmp/cyg-fast-packages)"
+        if [ $already = 0 ] && [ $installing = 0 ]; then
+          $cyg_fast -X -u --checkdep install $package
+          if [ $? -ne 0 ]; then warn=1; fi
         fi
-        $cyg_fast -X -u --checkdep install $package
-        if [ $? -ne 0 ]; then warn=1; fi
       done
     fi
     if [ $warn -ne 0 ]; then
@@ -739,15 +744,10 @@ function cyg-fast-install ()
       echo "Could not find \"install\" in package description: obsolete package?"
       exit 1
     fi
-
-    local file="$(basename "$install")"
-    echo "$mirror/$install" >> /tmp/cyg-fast-downloads
-    echo "  dir=release/$pkg" >> /tmp/cyg-fast-downloads
-    echo $pkg >> /tmp/cyg-fast-packages
-
+    
     # exit when recursively called
-    if [ $checkdep -ne 0 ]; then
-      exit
+    if [ $checkdep = 1 ]; then
+      exit 0
     fi
 
     done

--- a/cyg-fast
+++ b/cyg-fast
@@ -692,10 +692,11 @@ function cyg-fast-install ()
     done
 
     echo -n "Resolving dependencies..."
-
-    resolve_deps
+    
+    
     touch /tmp/cyg-fast-packages /tmp/cyg-fast-downloads
-
+    resolve_deps
+        
     RESUME_INSTALL=0
     cyg-fast-resume-install
 }
@@ -709,9 +710,8 @@ function resolve_deps()
     
     for pkg in $pkgs; do
 
-      local already="$(grep -c "$pkg " /etc/setup/installed.db)" 
       local installing="$( grep -c "$pkg" /tmp/cyg-fast-packages)"
-      if [ $already = 1 ] || [ $installing = 1 ] ; then
+      if [ $installing = 1 ] ; then
         continue;
       fi
 
@@ -743,9 +743,7 @@ function resolve_deps()
       if [ -n "$requires" ]; then
         for package in $requires; do
           local already="$(grep -c "$package " /etc/setup/installed.db)" 
-          local installing="$( grep -c "$package" /tmp/cyg-fast-packages)"
-          local processing="$( echo ${CURRENT[@]} ${pkgs[@]} | grep -c "$package" )"
-          if [ $already = 0 ] && [ $installing = 0 ] && [ $processing = 0 ] ; then
+          if [ $already = 0 ]; then
             hasdeps=1
             CURRENT=( ${CURRENT[@]} $package )
             if [ $? -ne 0 ]; then warn=1; fi

--- a/cyg-fast
+++ b/cyg-fast
@@ -27,38 +27,15 @@
 
 cyg_fast=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)/$(basename $0)
 
-TRUSTEDKEYS=( CYGWIN CYGWINPORTS );
-# ./cygwin.pub
-# ------------
-# pub   1024D/676041BA 2008-06-13
-# uid                  Cygwin <cygwin@cygwin.com>
-# sub   1024g/A1DB7B5C 2008-06-13
-TRUSTEDKEY_CYGWIN_MD5="8fe5366fc82289578ab9b6e3c9f1bff9"
-TRUSTEDKEY_CYGWIN_FPR="1169DF9F22734F743AA59232A9A262FF676041BA"
-TRUSTEDKEY_CYGWIN_URL="https://sourceware.org/cgi-bin/cvsweb.cgi/~checkout~/setup/cygwin.pub?rev=2.1&cvsroot=cygwin-apps"
-TRUSTEDKEY_CYGWIN_URL_LATEST="https://sourceware.org/cgi-bin/cvsweb.cgi/~checkout~/setup/cygwin.pub?cvsroot=cygwin-apps"
-# ./ports.gpg
-# -----------
-# pub   1024D/66EE1F94 2008-10-27
-# uid                  Yaakov Selkowitz (Cygwin Ports) <yselkowitz@users.sourceforge.net>
-# sub   4096g/7D66B0D2 2008-10-27
-TRUSTEDKEY_CYGWINPORTS_MD5="4c7904807340411f48f7519173cd600d"
-TRUSTEDKEY_CYGWINPORTS_FPR="45600BB98CA878AA97A70119FF20AF9A66EE1F94"
-TRUSTEDKEY_CYGWINPORTS_URL_LATEST="http://cygwinports.org/ports.gpg"
-
 # this script requires some packages
 
-TAR="$(  which tar  2>/dev/null )"
-GAWK="$( which awk  2>/dev/null )"
-GPGV="$( which gpgv 2>/dev/null )"
-GPG="$(  which gpg  2>/dev/null )"
-ARIA2C="$(  which aria2c  2>/dev/null )"
-if [ -z "$ARIA2C" -o -z "$TAR" -o -z "$GAWK" ]; then
+type aria2c tar gawk &> /dev/null || {
   echo You must install aria2, tar and gawk to use cyg-fast.
   exit 1
-fi
+}
 
-ARIA2C=( "${ARIA2C[@]}" "--conditional-get" "--allow-overwrite" )
+ARIA2C=( "aria2c" "--conditional-get" "--allow-overwrite" )
+
 function usage()
 {
   echo cyg-fast: Installs and removes Cygwin packages.
@@ -72,24 +49,19 @@ function usage()
   echo "  \"cyg-fast packageof <commands or files>\" to locate parent packages"
   echo "  \"cyg-fast pathof <cache|mirror|mirrordir|cache/mirrordir|setup.ini>\""
   echo "                                                          to show path"
-  echo "  \"cyg-fast key-add <files> ...\" to add keys contained in <files>"
-  echo "  \"cyg-fast key-del <keyids> ...\" to remove keys <keyids>"
-  echo "  \"cyg-fast key-list\" to list keys"
-  echo "  \"cyg-fast key-finger\" to list fingerprints"
   echo "  \"cyg-fast upgrade-self\" to upgrade cyg-fast"
   echo "Options:"
   echo "  --charch <arch>          : change archetecture"
   echo "  --use-setuprc            : set cache and mirror with /etc/setup/setup.rc"
   echo "  --ignore-case, -i        : ignore case distinctions for <patterns>"
   echo "  --force                  : force install/remove/fetch trustedkeys"
-  echo "  --no-verify, -X          : Don't verify setup.ini signatures"
-  echo "  --no-check-certificate   : Don't validate the server's certificate"
   echo "  --mirror, -m <url>       : set mirror"
   echo "  --cache, -c <dir>        : set cache"
   echo "  --file, -f <file>        : read package names from file"
   echo "  --noupdate, -u           : don't update setup.ini from mirror"
-  echo "  --rapid, -r              : -X, --no-check-certificate, -u, skip checking MD5"
+  echo "  --rapid, -r              : skip all optional functions"
   echo "  --max-connections <num>  : maximum number of connections"
+  echo "  --yes-to-all, -y         : force yes on ask prompts"
   echo "  --help"
   echo "  --version"
 }
@@ -140,19 +112,12 @@ function findworkspace()
   
   mkdir -p "$cache/$mirrordir/$arch"
   cd "$cache/$mirrordir/$arch"
-  
-  init_gnupg
-  fetch_trustedkeys
 }
 
-function download_and_verify ()
+function download ()
 {
   "${ARIA2C[@]}" "$1" || return 1
   [ -e "${1##*/}" ] || return 1
-  if [ -z "$no_verify" ]; then
-    "${ARIA2C[@]}" "${1}.sig" || return 1
-    [ -e "${1##*/}.sig" ] && verify_signatures "${1##*/}.sig" || { rm -f "${1##*/}" "${1##*/}.sig"; return 1; }
-  fi
   return
 }
 
@@ -187,14 +152,14 @@ function setupini_download ()
   local BASEDIR="$cache/$mirrordir/$arch"
   mkdir -p "$BASEDIR" || { echo -e "\e[31;1mError:\e[30;0m mkdir \"$BASEDIR\" failed."; exit 1; }
   
-  [ $noscripts -ne 0 -o $noupdate -ne 0 ] && return
+  (( noscripts || noupdate )) && return
   
   pushd "$BASEDIR"
   files_backup setup.ini setup.ini.sig setup.bz2 setup.bz2.sig
   
   while true; do
-    download_and_verify "$mirror/$arch/setup.bz2" && { bunzip2 -k setup.bz2 && mv setup setup.ini || rm -f setup.bz2; }
-    download_and_verify "$mirror/$arch/setup.ini" || break
+    download "$mirror/$arch/setup.bz2" && { bunzip2 -k setup.bz2 && mv setup setup.ini || rm -f setup.bz2; }
+    download "$mirror/$arch/setup.ini" || break
     
     files_backup_clean setup.ini setup.ini.sig setup.bz2 setup.bz2.sig
     popd
@@ -250,19 +215,6 @@ function charch ()
   fi
 }
 
-function init_gnupg ()
-{
-  [ -z "$GPG" ] && return
-  export GNUPGHOME="$cache/.cyg-fast"
-  if [ ! -d "$GNUPGHOME" ]; then
-    if ! { mkdir -p "$GNUPGHOME" && chmod 700 "$GNUPGHOME"; } then
-      echo -e "\e[31;1mError:\e[30;0m cannot initialize directory $GNUPGHOME"
-      exit 1
-    fi
-  fi
-  GPG_KEYRING=( --keyring pubring.gpg )
-}
-
 # Usage: ask_user "question?" (optional recognition of YES_TO_ALL=true auto yes)
 function ask_user ()
 {
@@ -279,153 +231,6 @@ function ask_user ()
          2*) return 1 ;;
     esac
   done
-}
-
-# Usage: wget_return_case_md5sum returncode
-function wget_return_case_md5sum ()
-{
-  case "$1" in
-    1) echo "$LABEL: FAILED: Could not download $URL."; return 1 ;;
-    5) echo "$LABEL: WARNING: The SSL certificate is invalid $URL."
-       ask_user "Continue regardless of invalid SSL certificate?" || return 1
-       "${ARIA2C[@]}" "$URL" -o "$FILE"
-       return 0
-    ;;
-    8) echo "$LABEL: FAILED: 404 Not Found $URL." return 1 ;;
-    0) return 0 ;;
-    *) echo -e "\e[31;1mError:\e[30;0m FATAL: wget returned unkown value"; return 1 ;;
-  esac
-}
-
-# Usage: wget_and_check_md5sum label hash url file
-function wget_and_check_md5sum ()
-{
-  local LABEL="$1"
-  local MD5="$2"
-  local URL="$3"
-  local FILE="$4"
-  "${ARIA2C[@]}" `[ -n $no_check_cert ] || echo "--check-certificate"` "$URL" -o "$FILE"
-  wget_return_case_md5sum "$?" || return 1
-  if ! { echo "$MD5 *$FILE" | md5sum -c >& /dev/null; } then
-    echo "$LABEL: FAILED: MD5 hash is not match."
-    return 2
-  fi
-  echo "$LABEL: OK"
-}
-
-function fetch_trustedkeys ()
-{
-  [ -z "$GPG" ] && return
-  local i
-  local FILE="$(mktemp)"
-  local FILE_LATEST="$(mktemp)"
-  for i in "${TRUSTEDKEYS[@]}"; do
-    local LABEL="TRUSTEDKEY_${i}"
-    local MD5="$(eval echo "\$${LABEL}_MD5")"
-    local FPR="$(eval echo "\$${LABEL}_FPR")"
-    local URL="$(eval echo "\$${LABEL}_URL")"
-    local URL_LATEST="$(eval echo "\$${LABEL}_URL_LATEST")"
-    local CASE=""
-    if ( [ -z "$force" ] || [ -n $rapid ] ) && { "${GPG[@]}" --fingerprint --with-colons | grep -q "$FPR"; } then
-      continue
-    fi
-    if [ -n "$URL" ]; then
-      wget_and_check_md5sum "$LABEL" "$MD5" "$URL" "$FILE"
-      CASE+="$?"
-    else
-      CASE+="-"
-    fi
-    if [ -n "$URL_LATEST" ]; then
-      wget_and_check_md5sum "$LABEL" "$MD5" "$URL_LATEST" "$FILE_LATEST"
-      CASE+="$?"
-    else
-      CASE+="-"
-    fi
-    case "$CASE" in
-      00|01|0-)
-        "${GPG[@]}" --import "$FILE"
-      ;;
-      02)
-        echo "Warning: ${LABEL} has been updated."
-        "${GPG[@]}" --import "$FILE"
-      ;;
-      -0)
-        "${GPG[@]}" --import "$FILE_LATEST"
-      ;;
-      10|20)
-        echo -e "\e[31;1mError:\e[30;0m ${LABEL} has miss configuration."
-        exit 1
-      ;;
-      11|1-|-1)
-        echo -e "\e[31;1mError:\e[30;0m Could not download ${LABEL}."
-        exit 1
-      ;;
-      12|-2)
-        echo -e "\e[31;1mError:\e[30;0m ${LABEL} has been updated, maybe. But sometimes it may has been cracked. Be careful !!!"
-        exit 1
-      ;;
-      21|22|2-)
-        echo -e "\e[31;1mError:\e[30;0m ${LABEL} has been cracked, maybe"
-        exit 1
-      ;;
-      --)
-        echo -e "\e[31;1mError:\e[30;0m ${LABEL} has no URL."
-        exit 1
-      ;;
-    esac
-  done
-  rm "$FILE" "$FILE_LATEST"
-}
-
-# Usage: verify_signatures files ...
-function verify_signatures ()
-{
-  while [ $# -gt 0 ]; do
-    if ! "${GPGV[@]}" "${GPG_KEYRING[@]}" "$1"; then
-      echo -e "\e[31;1mError:\e[30;0m BAD signature: $1"
-      return 1
-    fi
-    shift
-  done
-}
-
-# Usage: cyg-fast-key-add pkey ...
-function cyg-fast-key-add ()
-{
-  [ -z "$GPG" ] && { echo -e "\e[31;1mError:\e[30;0m GnuPG is not installed. Prease install gnupg package"; exit 1; }
-  local pkeys
-  for pkey; do
-    pkeys+=( "$(cygpath -a "$pkey" )" )
-  done
-  findworkspace
-  for pkey in "${pkeys[@]}"; do
-    "${GPG[@]}" --import "$pkey"
-  done
-}
-
-# Usage: cyg-fast-key-add keyid ...
-function cyg-fast-key-del ()
-{
-  [ -z "$GPG" ] && { echo -e "\e[31;1mError:\e[30;0m GnuPG is not installed. Prease install gnupg package"; exit 1; }
-  local keyid
-  findworkspace
-  for keyid; do
-    "${GPG[@]}" --batch --yes --delete-key "$keyid"
-  done
-}
-
-function cyg-fast-key-list ()
-{
-  [ -z "$GPG" ] && { echo -e "\e[31;1mError:\e[30;0m GnuPG is not installed. Prease install gnupg package"; exit 1; }
-  findworkspace
-  "${GPG[@]}" --list-keys
-}
-
-function cyg-fast-key-finger ()
-{
-  [ -z "$GPG" ] && { echo -e "\e[31;1mError:\e[30;0m GnuPG is not installed. Prease install gnupg package"; exit 1; }
-  findworkspace
-  "${GPG[@]}" --fingerprint
 }
 
 function cyg-fast-pathof ()
@@ -472,8 +277,6 @@ OPT_FILES=()
 SUBCOMMAND=""
 ignore_case=""
 force=""
-no_verify=""
-no_check_cert=""
 YES_TO_ALL=false
 maxcount=5
 INITIAL_ARGS=( "$@" )
@@ -507,16 +310,6 @@ while [ $# -gt 0 ]; do
       shift
     ;;
 
-    --no-verify|-X)
-      no_verify=1
-      shift
-    ;;
-
-    --no-check-certificate)
-      no_check_cert=1
-      shift
-    ;;
-
     --rapid|-r)
       no_verify=1
       noupdate=1
@@ -541,6 +334,11 @@ while [ $# -gt 0 ]; do
 
     --noupdate|-u)
       noupdate=1
+      shift
+    ;;
+
+    --yes-to-all|-y)
+      YES_TO_ALL=1
       shift
     ;;
 
@@ -576,11 +374,6 @@ while [ $# -gt 0 ]; do
 
   esac
 done
-
-if [ -z "$GPGV" -a -z "$no_verify" ]; then
-  echo -e "\e[31;1mError:\e[30;0m GnuPG is not installed. Prease install gnupg package or use -X option."
-  exit 1
-fi
 
 for file in "${OPT_FILES[@]}"; do
   if [ -f "$file" ]; then
@@ -691,8 +484,7 @@ function cyg-fast-install ()
       CURRENT="${CURRENT[@]} $pkg"
     done
 
-    echo -n "Resolving dependencies..."
-    
+    echo -n "Resolving dependencies.."
     
     touch /tmp/cyg-fast-packages /tmp/cyg-fast-downloads
     resolve_deps
@@ -781,7 +573,6 @@ function cyg-fast-resume-install()
     
     echo "Start downloading..."
     ${ARIA2C[@]} --deferred-input \
-                 `[ "$no_check_cert" = 1 ] || echo "--check-certificate"` \
                  --input-file /tmp/cyg-fast-downloads \
                  -x $maxcount || {
       echo "Interrupted: To resume installing, run \"cyg-fast resume-install\" ."
@@ -860,7 +651,7 @@ function cyg-fast-remove()
       continue
     fi
 
-    local dontremove="cygwin coreutils gawk bzip2 tar xz wget bash"
+    local dontremove="cygwin coreutils gawk bzip2 tar xz aria2 bash"
     for req in $dontremove; do
       if [ "$pkg" = "$req" ]; then
         echo cyg-fast cannot remove package $pkg, exiting

--- a/cyg-fast
+++ b/cyg-fast
@@ -89,7 +89,7 @@ function usage()
   echo "  --file, -f <file>        : read package names from file"
   echo "  --noupdate, -u           : don't update setup.ini from mirror"
   echo "  --ipv4, -4               : wget prefer ipv4"
-  echo "  --max-count, -m <count>  : maximum number of connections"
+  echo "  --max-count <count>      : maximum number of connections"
   echo "  --help"
   echo "  --version"
 }
@@ -545,7 +545,7 @@ while [ $# -gt 0 ]; do
       shift
     ;;
 
-    --max-count|-m)
+    --max-count)
       maxcount=$2
     ;;
 

--- a/cyg-fast
+++ b/cyg-fast
@@ -25,6 +25,7 @@
 # THE SOFTWARE.
 # 
 
+cyg_fast=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)/$(basename $0)
 TRUSTEDKEYS=( CYGWIN CYGWINPORTS );
 # ./cygwin.pub
 # ------------
@@ -46,33 +47,34 @@ TRUSTEDKEY_CYGWINPORTS_URL_LATEST="http://cygwinports.org/ports.gpg"
 
 # this script requires some packages
 
-WGET="$( which wget 2>/dev/null )"
 TAR="$(  which tar  2>/dev/null )"
 GAWK="$( which awk  2>/dev/null )"
 GPGV="$( which gpgv 2>/dev/null )"
 GPG="$(  which gpg  2>/dev/null )"
-if [ -z "$WGET" -o -z "$TAR" -o -z "$GAWK" ]; then
-  echo You must install wget, tar and gawk to use apt-cyg.
+WGET="$(  which wget 2>/dev/null )"
+ARIA2C="$(  which aria2c  2>/dev/null )"
+if [ -z "$ARIA2C" -o -z "$WGET" -o -z "$TAR" -o -z "$GAWK" ]; then
+  echo You must install aria2, wget, tar and gawk to use cyg-fast.
   exit 1
 fi
 
 function usage()
 {
-  echo apt-cyg: Installs and removes Cygwin packages.
-  echo "  \"apt-cyg install <package names>\" to install packages"
-  echo "  \"apt-cyg remove <package names>\" to remove packages"
-  echo "  \"apt-cyg update\" to update setup.ini"
-  echo "  \"apt-cyg show\" to show installed packages"
-  echo "  \"apt-cyg find <patterns>\" to find packages matching patterns"
-  echo "  \"apt-cyg describe <patterns>\" to describe packages matching patterns"
-  echo "  \"apt-cyg packageof <commands or files>\" to locate parent packages"
-  echo "  \"apt-cyg pathof <cache|mirror|mirrordir|cache/mirrordir|setup.ini>\""
+  echo cyg-fast: Installs and removes Cygwin packages.
+  echo "  \"cyg-fast install <package names>\" to install packages"
+  echo "  \"cyg-fast remove <package names>\" to remove packages"
+  echo "  \"cyg-fast update\" to update setup.ini"
+  echo "  \"cyg-fast show\" to show installed packages"
+  echo "  \"cyg-fast find <patterns>\" to find packages matching patterns"
+  echo "  \"cyg-fast describe <patterns>\" to describe packages matching patterns"
+  echo "  \"cyg-fast packageof <commands or files>\" to locate parent packages"
+  echo "  \"cyg-fast pathof <cache|mirror|mirrordir|cache/mirrordir|setup.ini>\""
   echo "                                                          to show path"
-  echo "  \"apt-cyg key-add <files> ...\" to add keys contained in <files>"
-  echo "  \"apt-cyg key-del <keyids> ...\" to remove keys <keyids>"
-  echo "  \"apt-cyg key-list\" to list keys"
-  echo "  \"apt-cyg key-finger\" to list fingerprints"
-  echo "  \"apt-cyg upgrade-self\" to upgrade apt-cyg"
+  echo "  \"cyg-fast key-add <files> ...\" to add keys contained in <files>"
+  echo "  \"cyg-fast key-del <keyids> ...\" to remove keys <keyids>"
+  echo "  \"cyg-fast key-list\" to list keys"
+  echo "  \"cyg-fast key-finger\" to list fingerprints"
+  echo "  \"cyg-fast upgrade-self\" to upgrade cyg-fast"
   echo "Options:"
   echo "  --charch <arch>          : change archetecture"
   echo "  --use-setuprc            : set cache and mirror with /etc/setup/setup.rc"
@@ -86,6 +88,7 @@ function usage()
   echo "  --file, -f <file>        : read package names from file"
   echo "  --noupdate, -u           : don't update setup.ini from mirror"
   echo "  --ipv4, -4               : wget prefer ipv4"
+  echo "  --max-count, -c <count>  : maximum number of connections"
   echo "  --help"
   echo "  --version"
 }
@@ -94,7 +97,7 @@ function usage()
 
 function version()
 {
-  echo "apt-cyg version 0.57"
+  echo "cyg-fast version 0.57"
   echo "Written by Stephen Jungels"
   echo ""
   echo "Copyright (c) 2005-9 Stephen Jungels.  Released under the GPL."
@@ -130,9 +133,11 @@ function findworkspace()
   fi
   mirror="${mirror%/}"
   mirrordir="$(mirror_to_mirrordir "$mirror/")"
-  
-  echo Working directory is $cache
-  echo Mirror is $mirror
+
+  if [ $checkdep -ne 1 ]; then
+    echo Working directory is $cache
+    echo Mirror is $mirror
+  fi
   mkdir -p "$cache/$mirrordir/$arch"
   cd "$cache/$mirrordir/$arch"
   
@@ -228,7 +233,7 @@ function getrootdir ()
   esac
 }
 
-# Usage: charch arch apt-cyg_parms ...
+# Usage: charch arch cyg-fast_parms ...
 function charch ()
 {
   local rootdir
@@ -248,7 +253,7 @@ function charch ()
 function init_gnupg ()
 {
   [ -z "$GPG" ] && return
-  export GNUPGHOME="$cache/.apt-cyg"
+  export GNUPGHOME="$cache/.cyg-fast"
   if [ ! -d "$GNUPGHOME" ]; then
     if ! { mkdir -p "$GNUPGHOME" && chmod 700 "$GNUPGHOME"; } then
       echo -e "\e[31;1mError:\e[30;0m cannot initialize directory $GNUPGHOME"
@@ -384,8 +389,8 @@ function verify_signatures ()
   done
 }
 
-# Usage: apt-cyg-key-add pkey ...
-function apt-cyg-key-add ()
+# Usage: cyg-fast-key-add pkey ...
+function cyg-fast-key-add ()
 {
   [ -z "$GPG" ] && { echo -e "\e[31;1mError:\e[30;0m GnuPG is not installed. Prease install gnupg package"; exit 1; }
   local pkeys
@@ -398,8 +403,8 @@ function apt-cyg-key-add ()
   done
 }
 
-# Usage: apt-cyg-key-add keyid ...
-function apt-cyg-key-del ()
+# Usage: cyg-fast-key-add keyid ...
+function cyg-fast-key-del ()
 {
   [ -z "$GPG" ] && { echo -e "\e[31;1mError:\e[30;0m GnuPG is not installed. Prease install gnupg package"; exit 1; }
   local keyid
@@ -409,21 +414,21 @@ function apt-cyg-key-del ()
   done
 }
 
-function apt-cyg-key-list ()
+function cyg-fast-key-list ()
 {
   [ -z "$GPG" ] && { echo -e "\e[31;1mError:\e[30;0m GnuPG is not installed. Prease install gnupg package"; exit 1; }
   findworkspace
   "${GPG[@]}" --list-keys
 }
 
-function apt-cyg-key-finger ()
+function cyg-fast-key-finger ()
 {
   [ -z "$GPG" ] && { echo -e "\e[31;1mError:\e[30;0m GnuPG is not installed. Prease install gnupg package"; exit 1; }
   findworkspace
   "${GPG[@]}" --fingerprint
 }
 
-function apt-cyg-pathof ()
+function cyg-fast-pathof ()
 {
   findworkspace >& /dev/null
   while [ "$#" -gt 0 ]; do
@@ -441,7 +446,7 @@ function apt-cyg-pathof ()
   done
 }
 
-function apt-cyg-upgrade-self ()
+function cyg-fast-upgrade-self ()
 {
   local basedir="$(dirname "$(readlink -f "$(which "$0")")")"
   if [ ! -d "$basedir/.git" ]; then
@@ -454,7 +459,7 @@ function apt-cyg-upgrade-self ()
 }
 
 
-function apt-cyg-help ()
+function cyg-fast-help ()
 {
   usage
 }
@@ -463,6 +468,7 @@ function apt-cyg-help ()
 
 noscripts=0
 noupdate=0
+checkdep=0
 OPT_FILES=()
 SUBCOMMAND=""
 ignore_case=""
@@ -470,6 +476,7 @@ force_remove=""
 force_fetch_trustedkeys=""
 no_verify=""
 YES_TO_ALL=false
+maxcount=5
 INITIAL_ARGS=( "$@" )
 ARGS=()
 
@@ -532,6 +539,15 @@ while [ $# -gt 0 ]; do
       shift
     ;;
 
+    --checkdep)
+      checkdep=1
+      shift
+    ;;
+
+    --max-count|-c)
+      maxcount=$2
+    ;;
+
     --ipv4|-4)
       WGET=( "${WGET[@]}" "--prefer-family=IPv4" )
       shift
@@ -585,7 +601,7 @@ done
 
 
 
-function apt-cyg-update ()
+function cyg-fast-update ()
 {
 
     findworkspace
@@ -594,7 +610,7 @@ function apt-cyg-update ()
 }
 
 
-function apt-cyg-show ()
+function cyg-fast-show ()
 {
 
     echo 1>&2 The following packages are installed:
@@ -603,7 +619,7 @@ function apt-cyg-show ()
 }
 
 
-function apt-cyg-find ()
+function cyg-fast-find ()
 {
     local pkg
 
@@ -625,7 +641,7 @@ function apt-cyg-find ()
 }
 
 
-function apt-cyg-describe ()
+function cyg-fast-describe ()
 {
     local pkg
 
@@ -642,7 +658,7 @@ function apt-cyg-describe ()
 }
 
 
-function apt-cyg-packageof ()
+function cyg-fast-packageof ()
 {
     local pkg
     local manifest
@@ -665,7 +681,7 @@ function apt-cyg-packageof ()
 }
 
 
-function apt-cyg-install ()
+function cyg-fast-install ()
 {
     local pkg
     local script
@@ -674,15 +690,15 @@ function apt-cyg-install ()
     findworkspace
     getsetup
 
-    for pkg do
+    [ $checkdep -ne 0 ] || echo -n "Resolving dependencies..."
 
+    for pkg do
+    echo -n "."
     local already="$(grep -c "^$pkg " /etc/setup/installed.db)"
     if [ $already -ge 1 ]; then
-      echo Package $pkg is already installed, skipping
+      echo; echo Package $pkg is already installed, skipping
       continue
     fi
-    echo ""
-    echo Installing $pkg
 
     # look for package and save desc file
 
@@ -693,13 +709,28 @@ function apt-cyg-install ()
        setup.ini
     local desc="$(< "release/$pkg/desc")"
     if [ "$desc" = "Package not found" ]; then
-      echo Package $pkg not found or ambiguous name, exiting
+      echo; echo Package $pkg not found or ambiguous name, exiting
       rm -r "release/$pkg"
       exit 1
     fi
-    echo Found package $pkg
 
-    # download and unpack the bz2 file
+    # resolve dependencies
+
+    local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
+    local warn=0
+    if [ -n "$requires" ]; then
+      for package in $requires; do
+        local already="$(grep -c "^$package " /etc/setup/installed.db)"
+        if [ $already -ge 1 ]; then
+          continue
+        fi
+        $cyg_fast -X -u --checkdep install $package
+        if [ $? -ne 0 ]; then warn=1; fi
+      done
+    fi
+    if [ $warn -ne 0 ]; then
+      echo "Warning: some required packages do not install, continuing"
+    fi
 
     # pick the latest version, which comes first
     local install="$(awk '/^install: / { print $2; exit }' "release/$pkg/desc")"
@@ -710,74 +741,88 @@ function apt-cyg-install ()
     fi
 
     local file="$(basename "$install")"
-    cd "release/$pkg"
-    "${WGET[@]}" -nc $mirror/$install
-    
-    # check the md5
-    local digest="$(awk '/^install: / { print $4; exit }' "desc")"
-    local digactual="$(md5sum $file | awk '{print $1}')"
-    if [ "$digest" != "$digactual" ]; then
-      echo MD5 sum did not match, exiting
-      exit 1
+    echo "$mirror/$install" >> /tmp/cyg-fast-downloads
+    echo "  dir=release/$pkg" >> /tmp/cyg-fast-downloads
+    echo $pkg >> /tmp/cyg-fast-packages
+
+    # exit when recursively called
+    if [ $checkdep -ne 0 ]; then
+      exit
     fi
+
+    done
+
+    [ -f "/tmp/cyg-fast-packages" ] || exit
+    echo ""
+    echo "Following packages will be installed:"
+    for p in $( cat /tmp/cyg-fast-packages ); do
+      echo -n $p " "
+    done
+    echo ""
+    read -p "Do you wish to continue? [y/N] " yn
+    case $yn in
+      [Yy]* ) ;;
+      * ) quit;;
+    esac
+
+    # download all
+    echo "Start downloading..."
+    aria2c --conditional-get --deferred-input=true --input-file=/tmp/cyg-fast-downloads -x $maxcount
+
+    # unpack all
+    for pkg in $( cat /tmp/cyg-fast-packages ); do
+
+      install="$(awk '/^install: / { print $2; exit }' "release/$pkg/desc")"
+      file="$(basename "$install")"
+      
+      cd "release/$pkg"
+      # check the md5
+      local digest="$(awk '/^install: / { print $4; exit }' "desc")"
+      local digactual="$(md5sum $file | awk '{print $1}')"
+      if [ "$digest" != "$digactual" ]; then
+        echo MD5 sum did not match, exiting
+        exit 1
+      fi
+      
+      echo "Unpacking: $pkg"
+      tar > "/etc/setup/$pkg.lst" xvf "$file" -C /
+      gzip -f "/etc/setup/$pkg.lst"
+      cd ../..
     
-    echo "Unpacking..."
-    tar > "/etc/setup/$pkg.lst" xvf "$file" -C /
-    gzip -f "/etc/setup/$pkg.lst"
-    cd ../..
-    
-    
-    # update the package database
-    
-    awk > /tmp/awk.$$ -v pkg="$pkg" -v bz=$file \
-      '{if (ins != 1 && pkg < $1) {print pkg " " bz " 0"; ins=1}; print $0} \
-      END{if (ins != 1) print pkg " " bz " 0"}' \
-      /etc/setup/installed.db
-    mv /etc/setup/installed.db /etc/setup/installed.db-save
-    mv /tmp/awk.$$ /etc/setup/installed.db
-    
-    
-    # recursively install required packages
-    
-    local requires="$(grep "^requires: " "release/$pkg/desc" | sed -re 's/^requires: *(.*[^ ]) */\1/g' -e 's/ +/ /g')"
-    
-    local warn=0
-    if [ -n "$requires" ]; then
-      echo Package $pkg requires the following packages, installing:
-      echo $requires
-      for package in $requires; do
-        local already="$(grep -c "^$package " /etc/setup/installed.db)"
-        if [ $already -ge 1 ]; then
-          echo Package $package is already installed, skipping
-          continue
-        fi
-        apt-cyg --noscripts install $package
-        if [ $? -ne 0 ]; then warn=1; fi
-      done
-    fi
-    if [ $warn -ne 0 ]; then
-      echo "Warning: some required packages did not install, continuing"
-    fi
+      # update the package database
+
+      awk > /tmp/awk.$$ -v pkg="$pkg" -v bz=$file \
+        '{if (ins != 1 && pkg < $1) {print pkg " " bz " 0"; ins=1}; print $0} \
+        END{if (ins != 1) print pkg " " bz " 0"}' \
+        /etc/setup/installed.db
+      mv /etc/setup/installed.db /etc/setup/installed.db-save
+      mv /tmp/awk.$$ /etc/setup/installed.db
+    done
     
     # run all postinstall scripts
     
     local pis="$(ls /etc/postinstall/*.sh 2>/dev/null | wc -l)"
     if [ $pis -gt 0 -a $noscripts -ne 1 ]; then
-      echo Running postinstall scripts
+      echo Running postinstall scripts...
       for script in /etc/postinstall/*.sh; do
         $script
         mv $script $script.done
       done
     fi
-    
-    echo Package $pkg installed
-
-    done
-
+    quit
 }
 
 
-function apt-cyg-remove()
+function quit()
+{
+    echo "Removing tmp files..."
+    rm /tmp/cyg-fast-downloads
+    rm /tmp/cyg-fast-packages
+    echo Done.
+    exit
+}
+
+function cyg-fast-remove()
 {
     local pkg
     local req
@@ -794,7 +839,7 @@ function apt-cyg-remove()
     local dontremove="cygwin coreutils gawk bzip2 tar xz wget bash"
     for req in $dontremove; do
       if [ "$pkg" = "$req" ]; then
-        echo apt-cyg cannot remove package $pkg, exiting
+        echo cyg-fast cannot remove package $pkg, exiting
         exit 1
       fi
     done
@@ -826,7 +871,7 @@ function invoke_subcommand ()
 {
     local SUBCOMMAND="${@:1:1}"
     local ARGS=( "${@:2}" )
-    local ACTION="apt-cyg-${SUBCOMMAND:-help}"
+    local ACTION="cyg-fast-${SUBCOMMAND:-help}"
     if type "$ACTION" >& /dev/null; then
       "$ACTION" "${ARGS[@]}"
     else


### PR DESCRIPTION
cyg-fast verify digest only by md5, but now exists distro with digest sha512.

here is a patch for it.

```
diff --git a/cyg-fast b/cyg-fast
index e717caf..879a748 100755
--- a/cyg-fast
+++ b/cyg-fast
@@ -627,12 +627,19 @@ function cyg-fast-resume-install()
       # check the md5
 
       while true; do
-        local digest="$(awk '/^install: / { print $4; exit }' "desc")"
-        local digactual="$(md5sum $file | awk '{print $1}')"
-        if [ "$digest" != "$digactual" ]; then
-          error "MD5 sum did not match, retry downloading..."
-          aria2c $mirror/$install
-        else break; fi
+          local digest="$(awk '/^install: / { print $4; exit }' "desc")"
+          local sumcmd
+          case "$(echo $digest | wc -c)" in
+              33) sumcmd=md5sum;;
+              129) sumcmd=sha512sum;;
+              *) error "Cannot determine checksum ... ABORT!!";
+                  exit 1;;
+          esac
+          local digactual="$($sumcmd $file | awk '{print $1}')"
+          if [ "$digest" != "$digactual" ]; then
+              error "MD5 sum did not match, retry downloading..."
+              aria2c $mirror/$install
+          else break; fi
       done
       
       echo "Unpacking: $pkg"
```
Regards.