### PR TITLE
workaround to avoid warning for INSTALLED.DB 3

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -613,7 +613,7 @@ PACKAGE_DB="/etc/setup/installed.db"
 function package_db-version_check ()
 {
   local ver2hdr="INSTALLED.DB 2"
-  if [ $(head -n1 installed.db | cut -d ' ' -f 2) -lt 2 ]; then
+  if [ $(head -n1 ${PACKAGE_DB} | cut -d ' ' -f 2) -lt 2 ]; then
   if head -n1 "${PACKAGE_DB}" | grep -Fqvx "${ver2hdr}"; then
     echo -e "\e[33;1mWarning:\e[30;0m ${PACKAGE_DB} is not version 2. The first line is below:"
     echo -e "$(head -n1 "${PACKAGE_DB}")\n" >&2

--- a/apt-cyg
+++ b/apt-cyg
@@ -613,7 +613,7 @@ PACKAGE_DB="/etc/setup/installed.db"
 function package_db-version_check ()
 {
   local ver2hdr="INSTALLED.DB 2"
-  
+  if [ $(head -n1 installed.db | cut -d ' ' -f 2) -lt 2 ]; then
   if head -n1 "${PACKAGE_DB}" | grep -Fqvx "${ver2hdr}"; then
     echo -e "\e[33;1mWarning:\e[30;0m ${PACKAGE_DB} is not version 2. The first line is below:"
     echo -e "$(head -n1 "${PACKAGE_DB}")\n" >&2
@@ -622,6 +622,7 @@ function package_db-version_check ()
     if grep -FHnx "${ver2hdr}" "${PACKAGE_DB}" >&2; then
       echo -e "The above line looks like version header, but it is not the first line.\n" >&2
     fi
+  fi
   fi
 }
 


### PR DESCRIPTION
Warning: /etc/setup/installed.db is not version 2. The first line is below:
INSTALLED.DB 3