### PR TITLE
Added support for Setup.exe to use same mirror and cache dir as apt-cyg

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -1104,10 +1104,25 @@ function apt-cyg-setup ()
 
 function apt-cyg-dist-upgrade-no-ask ()
 {
+
+  local cache_string="";
+  local mirror_string="";
+
   pushd "$(apt-cyg-pathof cache)" > /dev/null
+  if [ "$?" == "0" ]; then
+    local windir_cache="$(cygpath -wa .)"
+    cache_string="-l ${windir_cache} "
+  fi
+
+  local mirror=$(apt-cyg-pathof mirror)
+  if [  "$?" == "0" ]; then
+    mirror_string="-s ${mirror} "
+  fi
   
+  ### https://cygwin.com/faq/faq.html#faq.setup.cli
+
   apt-cyg-update-setup
-  cygstart cmd /c 'ECHO Press any key to start dist-upgrade for cygwin '"$(current_cygarch)"' && PAUSE && START /WAIT .\'"${SETUP_EXE}"' -B -q -n -g && ash -c "/bin/rebaseall -v" && ECHO dist-upgrade is finished && ECHO Press any key to exit && PAUSE' # '
+  cygstart cmd /c 'ECHO Press any key to start dist-upgrade for cygwin '"$(current_cygarch)"' && PAUSE && START /WAIT .\'"${SETUP_EXE}"' -B -q -n -g '"${w_cache}${mirror_string}"' && ash -c "/bin/rebaseall -v" && ECHO dist-upgrade is finished && ECHO Press any key to exit && PAUSE' # '
   kill_all_cygwin_process
   
   popd > /dev/null

--- a/apt-cyg
+++ b/apt-cyg
@@ -146,8 +146,7 @@ function verbose ()
 # Usage: verbosefor [level]
 function verbosefor ()
 {
-  (( "${OPT_VERBOSE_LEVEL}" < "${1:-1}" )) && { echo "/dev/null"; return; }
-  echo "/dev/stderr"
+  (( ${OPT_VERBOSE_LEVEL} < ${1:-1} )) && echo "/dev/null" || echo "/dev/stderr"
 }
 
 function current_cygarch ()
@@ -1609,6 +1608,12 @@ wget --help | grep -- --no-verbose    &>/dev/null && HAVE_NO_VERBOSE="--no-verbo
 (( "${OPT_VERBOSE_LEVEL}" < 0 )) && WGET+=( --quiet ) || \
 (( "${OPT_VERBOSE_LEVEL}" < 1 )) && WGET+=( --quiet $HAVE_SHOW_PROGRESS ) || \
 (( "${OPT_VERBOSE_LEVEL}" < 2 )) && WGET+=( $HAVE_NO_VERBOSE $HAVE_SHOW_PROGRESS )
+verbosefor0=$(verbosefor 0)
+verbosefor1=$(verbosefor 1)
+verbosefor2=$(verbosefor 2)
+verbosefor3=$(verbosefor 3)
+verbosefor4=$(verbosefor 4)
+verbosefor5=$(verbosefor 5)
 
 
 
@@ -1662,7 +1667,6 @@ function apt-cyg-describe ()
       setup.ini
   done
 }
-
 
 function apt-cyg-packageof ()
 {

--- a/apt-cyg
+++ b/apt-cyg
@@ -98,6 +98,7 @@ function usage()
   echo "  \"apt-cyg download\" download the binary package into the current directory."
   echo "  \"apt-cyg mirror\" download the binary package into the current cache/mirrordir as mirror."
   echo "Options:"
+  echo "  --ag                     : use the silver searcher (currently work only at packageof subcommand)"
   echo "  --charch <arch>          : change archetecture"
   echo "  --use-setuprc            : set cache and mirror with /etc/setup/setup.rc"
   echo "  --ignore-case, -i        : ignore case distinctions for <patterns>"
@@ -1457,6 +1458,11 @@ function parse_args ()
   while [ $# -gt 0 ]; do
     case "$1" in
       
+      --ag)
+        OPT_AG="$1"
+        shift
+        ;;
+      
       --charch)
         OPT_CHARCH="$2"
         shift 2 || break
@@ -1678,6 +1684,14 @@ verbosefor3=$(verbosefor 3)
 verbosefor4=$(verbosefor 4)
 verbosefor5=$(verbosefor 5)
 
+if [ -n "$OPT_AG" ]; then
+  AG="$( which ag 2>/dev/null )"
+  if [ -z "$AG" ]; then
+    echo -e "\e[33;1mWarning:\e[0m ag is not found."
+    unset OPT_AG
+  fi
+fi
+
 
 
 function apt-cyg-update ()
@@ -1733,8 +1747,12 @@ function apt-cyg-describe ()
 
 function apt-cyg-packageof ()
 {
-  update_packageof_cache
-  zcat "$PACKAGEOF_CACHE" | grep "$@"
+  if [ -z "$OPT_AG" ]; then
+    update_packageof_cache
+    zcat "$PACKAGEOF_CACHE" | grep "$@"
+  else
+    "$AG" -z "$@" /etc/setup/*.lst.gz
+  fi
 }
 
 function apt-cyg-install ()

--- a/apt-cyg
+++ b/apt-cyg
@@ -103,6 +103,8 @@ function usage()
   echo "  --ignore-case, -i        : ignore case distinctions for <patterns>"
   echo "  --force-remove           : force remove"
   echo "  --force-fetch-trustedkeys: force fetch trustedkeys"
+  echo "  --force-update-packageof-cache:"
+  echo "                             force update packageof cache"
   echo "  --no-verify, -X          : Don't verify setup.ini signatures"
   echo "  --no-check-certificate   : Don't validate the server's certificate"
   echo "  --no-update-setup        : Don't update setup.exe"
@@ -119,6 +121,7 @@ function usage()
   echo "  --file, -f <file>        : read package names from file"
   echo "  --noupdate, -u           : don't update setup.ini from mirror"
   echo "  --ipv4, -4               : wget prefer ipv4"
+  echo "  --no-progress            : hide the progress bar in any verbosity mode"
   echo "  --quiet, -q              : quiet (no output)"
   echo "  --verbose, -v            : verbose"
   echo "  --help"
@@ -1302,6 +1305,56 @@ function apt-cyg-mirror ()
   download_packages mirror curr install "$@"
 }
 
+PACKAGEOF_CACHE="/tmp/.apt-cyg-packageof.cache.gz"
+function update_packageof_cache ()
+{
+  local i=0 p q path fn
+  local chr=( "=" "-" "/" "|" "\\" )
+  local lstgz_stamp="$(find /etc/setup/ -maxdepth 1 -type f -name '*.lst.gz' -exec stat -c %Y {} + | sort | tail -n1)"
+  local cache_stamp="$(stat "$PACKAGEOF_CACHE" -c %Y 2>/dev/null || echo 0)"
+  local n="$(ls -1 /etc/setup/*.lst.gz|wc -l)"
+  
+  if (( cache_stamp < lstgz_stamp )) || [ -n "$OPT_FORCE_UPDATE_PACKAGEOF_CACHE" ]; then
+    verbose 1 "Updating packageof cache:" >&2
+    progress_init
+    for path in /etc/setup/*.lst.gz; do
+      progress_update $(( i++ )) $n
+      local fn="${path##*/}"
+      zcat "$path" | awk -v PKGNAME="${fn%.lst.gz}" '{print PKGNAME ": " $0;}'
+#      printf "p=%d q=%d i=%d n=%d path=[%s]\n" $p $q $i $n "$path"
+    done | gzip >"$PACKAGEOF_CACHE"
+    progress_finish
+  fi
+}
+
+PROGRESS_CHAR=( "=" "-" "/" "|" "\\" )
+function progress_init ()
+{
+  [ -n "$OPT_NO_PROGRESS" ] && return
+  #          0        1         2         3         4         5
+  #          12345678901234567890123456789012345678901234567890
+  echo -ne "|..................................................|\r" >"$verbosefor0"
+}
+
+function progress_update () #= current total=100
+{
+  [ -n "$OPT_NO_PROGRESS" ] && return
+  local n=${2:-100}
+  local p=$((2 + 50 * ($1    ) / $n))
+  local q=$((2 + 50 * ($1 + 1) / $n))
+  if (( q - p <= 1 )); then
+    printf "\e[%dG%s" $p "${PROGRESS_CHAR[($1 % 4 + 1) * (1 + $p - $q)]}" >"$verbosefor0"
+  else
+    printf "\e[%dG%s" $p "$(seq $((q - p))|awk '{printf "="}')" >"$verbosefor0"
+  fi
+}
+
+function progress_finish ()
+{
+  [ -n "$OPT_NO_PROGRESS" ] && return
+  echo >"$verbosefor0"
+}
+
 # Lesser Parallel for Embedding
 # Copyright (c) 2014 Koichi OKADA. All rights reserved.
 # The official repository is:
@@ -1430,6 +1483,11 @@ function parse_args ()
         shift
         ;;
       
+      --force-update-packageof-cache)
+        OPT_FORCE_UPDATE_PACKAGEOF_CACHE="$1"
+        shift
+        ;;
+      
       --no-verify|-X)
         OPTS4INHERIT+=( "$1" )
         no_verify=1
@@ -1511,6 +1569,11 @@ function parse_args ()
       
       --ipv4|-4)
         WGET=( "${WGET[@]}" "--prefer-family=IPv4" )
+        shift
+        ;;
+      
+      --no-progress)
+        OPT_NO_PROGRESS="$1"
         shift
         ;;
       
@@ -1670,23 +1733,8 @@ function apt-cyg-describe ()
 
 function apt-cyg-packageof ()
 {
-  local pkg
-  local manifest
-  
-  checkpackages "$@"
-  for pkg do
-    local key="$(which "$pkg" 2>/dev/null | sed "s:^/::")"
-    if [ -z "$key" ]; then
-      key="$pkg"
-    fi
-    for manifest in /etc/setup/*.lst.gz; do
-      local found="$(gzip -cd "$manifest" | grep -c "$key")"
-      if [ $found -gt 0 ]; then
-        local package="$(echo $manifest | sed -e "s:/etc/setup/::" -e "s/.lst.gz//")"
-        echo Found $key in the package $package
-      fi
-    done
-  done
+  update_packageof_cache
+  zcat "$PACKAGEOF_CACHE" | grep "$@"
 }
 
 function apt-cyg-install ()


### PR DESCRIPTION
Mirror and Cache dirs are passed with -s and -l command line switches.

This works great for me. If it doesn't work for you, check permissions on cache folder.
