### PR TITLE
Force current cygwin root to be used by setup on dist-upgrade

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -1121,7 +1121,7 @@ function apt-cyg-setup ()
 function apt-cyg-dist-upgrade-no-ask ()
 {
   local opts; readarray -t opts < <(use_own_conf)
-  local setup=( ".\\${SETUP_EXE}" -B -q -n -g "${opts[@]}")
+  local setup=( ".\\${SETUP_EXE}" -R "$(cygpath -wa / | sed 's/\\/\\\\/g')" -B -q -n -g "${opts[@]}")
   
   pushd "$(apt-cyg-pathof cache)" > /dev/null
   


### PR DESCRIPTION
This patch fixes a problem where setup.exe cannot find your cygwin rootdir and assumes c:\cygwin.

Setup.exe is invoked with rootdir resolved by cygpath.
This is probably not bullet proof - for instance i'm guessing running dist-upgrade under chroot would break things.