### PR TITLE
Make apt-cyg update work

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -312,7 +312,7 @@ function init_gnupg ()
       exit 1
     fi
   fi
-  GPG_KEYRING=( --keyring pubring.gpg )
+  GPG_KEYRING=( --keyring pubring.kbx )
 }
 
 # Usage: ask_user [MESSAGE [OPTIONS]]
@@ -475,7 +475,7 @@ function fetch_trustedkeys ()
 function verify_signatures ()
 {
   while [ $# -gt 0 ]; do
-    if ! "${GPG[@]}" "${GPG_KEYRING[@]}" "$1" &> $(verbosefor 2); then
+    if ! "${GPG[@]}" --no-default-keyring "${GPG_KEYRING[@]}" --verify "$1" &> $(verbosefor 2); then
       echo -e "\e[31;1mError:\e[30;0m BAD signature: $1" >&2
       return 1
     else


### PR DESCRIPTION
Summary:
I get "bad signature" errors when I try to run "apt-cyg update".

Expected:
```
apt-cyg update
...skip...
signature verified: setup.bz2.sig
...skip...
```

Actual:
```
Cache directory is /setup
Mirror is http://cygwin.mirror.constant.com
Updating setup.ini
setup.bz2      100%[=========================================================>]   3.53M  2.53MB/s    in 1.4s
2018-04-23 16:26:24 URL:http://cygwin.mirror.constant.com/x86/setup.bz2 [3700347/3700347] -> "setup.bz2" [1]
setup.bz2.sig  100%[=========================================================>]      72  --.-KB/s    in 0s
2018-04-23 16:26:24 URL:http://cygwin.mirror.constant.com/x86/setup.bz2.sig [72/72] -> "setup.bz2.sig" [1]
Error: BAD signature: setup.bz2.sig
```

1. Use --verify to avoid "gpg: WARNING: no command supplied.  Trying to guess what you mean ..."
2. Use --keyring pubring.kbx because pubring.gpg does not exist (at least not for my tests)
3. Use --no-default-keyring (I wish I knew exactly why, I just know that gpg returns 2 not 0 if you don't use that)

Even with all of that you still need to interactively set up gpg by running these after running apt-cyg for the first time:
```
export GNUPGHOME="$cache/.apt-cyg"
gpg --gen-key
gpg --edit-key Cygwin # (set trust to 4)
gpg --edit-key Yaakov
```

Elaboration on "set trust to 4":
at the `gpg>` prompt type `trust` and at the next prompt type `4`