### PR TITLE
Add new command "category" from original apt-cyg

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -230,6 +230,7 @@ function usage()
 	                             List files 'owned' by package(s).
 	  get-proxy                : Get proxies for eval.
 	  ls-categories            : List categories.
+	  category                 : List all packages in given category.
 	  setuprc-get <section>    : Get section from 'setup.rc'.
 	  set-cache [<cache>]      : Set cache.
 	  set-mirror [<mirrors> ...] :
@@ -1233,7 +1234,7 @@ function __apt-cyg ()
   subcmd="$( "${getsubcmd[@]}" )"
   
   case "$subcmd" in
-    install|depends|rdepends|describe|find)
+    install|depends|rdepends|describe|find|category)
       COMPREPLY=( $(awk '/^@ /{print $2}' "$(apt-cyg pathof setup.ini)") )
       ;;
     remove)
@@ -2173,6 +2174,27 @@ function apt-cyg-find ()
     awk -v query="$pkg" -v IGNORECASE="$ignore_case" \
       'BEGIN{RS="\n\n@ "; FS="\n"; ORS="\n"} {if ($1 ~ query) {print $1}}' \
       setup.ini
+  done
+}
+
+
+function apt-cyg-category ()
+{
+  local pkg
+
+  checkpackages "$@"
+  findworkspace
+  getsetup
+
+  for pkg do
+    awk '
+    $1 == "@" {
+      pcat = $2
+    }
+    $1 == "category:" && $0 ~ query {
+      print pcat
+    }
+    ' query="$pkg" setup.ini
   done
 }
 


### PR DESCRIPTION
Added a new command for category that will list all packages belonging to the given category. Code is from original transcode/apt-cyg.