### PR TITLE
make wget upgrade-self use no-check-certificate

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -846,7 +846,12 @@ function upgrade-self-with-wget ()
 {
   local updated_url='https://raw.githubusercontent.com/kou1okada/apt-cyg/master/apt-cyg' # TODO: Do not use MAGIC NUMBER
   local temp_file=$(mktemp)
-  "${WGET[@]}" "${updated_url}" -q -O "$temp_file"
+	
+	# don't get certificates for wget when running upgrade-self
+	# on systems where it's needed, leaving it out creates an empty file
+	local extra_wget_option='--no-check-certificate'
+	
+  "${WGET[@]}" "${extra_wget_option}" "${updated_url}" -q -O "$temp_file"
   chmod +x "$temp_file"
   { diff "$temp_file" "$SCRIPT_REALPATH" >/dev/null && exit 0; } || cp "$temp_file" "$SCRIPT_REALPATH"
   rm "$temp_file"


### PR DESCRIPTION
In a system that needs no-check-certificate, calling wget without it creates a copy of the file that's empty/useless.

So, this makes the default fallback not check certificates.