### PR TITLE
Check that iconv command exists

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -75,6 +75,14 @@ function abort () #= [EXITCODE=1 [CALLSTACKSKIP=0]]
   exit "${1:-1}"
 }
 
+function assert_command_exists () #= [COMMAND ...]
+{
+  local command
+  for command in $@; do
+    hash $command 2>/dev/null || { error "Required command [$command] not found."; exit 1; }
+  done
+}
+
 function dump_callstack () #= [N=1]
 #? N is a depth to skip the callstack.
 #? $CALLSTACK_SKIP is depth to skip the callstack too.
@@ -2561,6 +2569,7 @@ function invoke_subcommand ()
   local ARGS=( "${@:2}" )
   local ACTION="apt-cyg-${SUBCOMMAND:-help}"
   if type "$ACTION" >& /dev/null; then
+    assert_command_exists iconv
     "$ACTION" "${ARGS[@]}"
   else
     error "unknown subcommand: $SUBCOMMAND"


### PR DESCRIPTION
libiconv and thus the iconv command may not be present in a cygwin installation.

This PR adds a check for the availability of iconv on PATH.

Without this check apt-cyg reports very misleading error messages as iconv is called indirectly in a subshell via an eval command. This results in apt-cyg not aborting when the command is not present.

Without this PR:
```
$ apt-cyg find upx
cygpath: can't convert empty path
/usr/local/bin/apt-cyg: line 535: declare: last_cache: not found
/usr/local/bin/apt-cyg: line 535: declare: last_mirror: not found
Cache directory is
Mirror is
Updating setup.ini
/x86_64/setup.bz2: Scheme missing.
/x86_64/setup.bz2.sig: Scheme missing.
/x86_64/setup.ini: Scheme missing.
/x86_64/setup.ini.sig: Scheme missing.
Error: updating setup.ini failed, reverting.
at : /usr/local/bin/apt-cyg: setupini_download: 624

Searching for installed packages matching upx:

Searching for installable packages matching upx:
awk: cmd. line:1: fatal: cannot open file `setup.ini' for reading: No such file or directory
```

With this PR:
```
$ apt-cyg find upx
Error: Required command [iconv] not found.
at : /usr/local/bin/apt-cyg: assert_command_exists: 82
```