### PR TITLE
Bugfix: Cygwin 3.3.6 can't execute "${COMSPEC//\\//}".

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -421,7 +421,7 @@ function comspec () # [<parameters> ...]
 # Call $COMSPEC.
 {
   init_comspec
-  PATH="$SYSTEMPATH" "${COMSPEC//\\//}" "$@"
+  PATH="$SYSTEMPATH" "$(cygpath "$COMSPEC")" "$@"
 }
 
 function cygstart () # [<parameters> ...]


### PR DESCRIPTION
* This patch will fix issue #88.

I would like to thank @zoidby, @kirusyaga, @darklie and @jarnosz who reported it.