### PR TITLE
Fix maybe unintentional behavior in setupini_download().

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -629,15 +629,15 @@ function setupini_download ()
     false \
     || { download_and_verify "$mirror/$arch/setup.zst" && { zstd  -dfkq setup.zst && mv setup setup.ini || rm -f setup.zst; }; } \
     || { download_and_verify "$mirror/$arch/setup.xz"  && { xz    -dfk  setup.xz  && mv setup setup.ini || rm -f setup.xz;  }; } \
-    || { download_and_verify "$mirror/$arch/setup.bz2" && { bzip2 -dfk  setup.bz2 && mv setup setup.ini || rm -f setup.bz2; }; }
-    download_and_verify "$mirror/$arch/setup.ini" || break
+    || { download_and_verify "$mirror/$arch/setup.bz2" && { bzip2 -dfk  setup.bz2 && mv setup setup.ini || rm -f setup.bz2; }; } \
+    || download_and_verify "$mirror/$arch/setup.ini" || break
     
     files_backup_clean setup.{zst,xz,bz2,ini}{,.sig}
     popd > /dev/null
     verbose 1 "Updated setup.ini"
     return
   done
-  files_restore setup.ini setup.ini.sig setup.bz2 setup.bz2.sig
+  files_restore setup.{zst,xz,bz2,ini}{,.sig}
   popd > /dev/null
   error "updating setup.ini failed, reverting."
   return 1


### PR DESCRIPTION
- A plain setup.ini is always downloaded even though it is successful to download one of compressed versions.
- Arguments for files_restore() is not aligned with files_backup() and files_backup_clean().

My own package site provides compressed versions only, and it causes error by break and a left backup because .xz is used.