### PR TITLE
Add --mirror-index|-M option to choose a mirror.

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -182,7 +182,7 @@ function usage()
 	  describe <patterns> ...  : to describe packages matching patterns
 	  packageof <command or file names> ... :
 	                             to locate parent packages
-	  pathof {cache|mirror|mirrordir|cache/mirrordir|setup.ini} :
+	  pathof {cache|mirror|mirrordir|cache/mirrordir|setup.ini|lastmirror} :
 	                             to show path
 	  key-add <files> ...      : to add keys contained in <files>
 	  key-del <keyids> ...     : to remove keys <keyids>
@@ -290,6 +290,8 @@ function usage()
 	                             disable completion autoupdate
 	  --max-jobs, -j <n>       : Run <n> jobs in parallel
 	  --mirror, -m <url>       : set mirror
+	  --mirror-index, -M <n>   : choose mirror from last-mirror list.
+	                             <n> is 0-based index in last-mirror.
 	  --cache, -c <dir>        : set cache
 	  --file, -f <file>        : read package names from <file>
 	  --noupdate, -u           : don't update setup.ini from mirror
@@ -567,6 +569,18 @@ function findworkspace()
 
     save_vars_to_cache "${cachevars[@]}"
   }
+  # apt-cyg-pathof suppresses output from fd 1 and fd 2,
+  # and fd 3 is duplicated from actual fd 2 for bypass.
+  # Other callers don't have fd 3, so check it and duplicate fd 2 to fd 3.
+  { exec 2>&3; } 2>/dev/null || exec 3>&2
+  [ -z "$OPT_MIRROR_INDEX" ] || {
+    [[ $OPT_MIRROR_INDEX =~ ^[0-9]+$ ]] && \
+      (( 0 <= $OPT_MIRROR_INDEX && $OPT_MIRROR_INDEX < ${#last_mirror[@]} )) || \
+        { error "mirror index must be from 0 to $((${#last_mirror[@]}-1)), inclusive"; exit 1; }
+    mirror="${last_mirror[OPT_MIRROR_INDEX]}"
+    mirror="${mirror%/}"
+    mirrordir="$(mirror_to_mirrordir "$mirror/")"
+  } 2>&3
 
   verbose 1 "Cache directory is $cache"
   verbose 1 "Mirror is $mirror"
@@ -916,7 +930,7 @@ function apt-cyg-key-finger ()
 
 function apt-cyg-pathof ()
 {
-  findworkspace >& /dev/null
+  findworkspace 3>&2 >& /dev/null
   while [ "$#" -gt 0 ]; do
     case "$1" in
       cache)            echo "$cache" ;;
@@ -924,6 +938,7 @@ function apt-cyg-pathof ()
       mirrordir)        echo "$mirrordir" ;;
       cache/mirrordir)  echo "$cache/$mirrordir" ;;
       setup.ini)        echo "$cache/$mirrordir/$arch/setup.ini" ;;
+      lastmirror)       echo "${last_mirror[@]}" ;;
       *)
         error "unknown parameter: $1"
         exit 1
@@ -1355,16 +1370,17 @@ function __apt-cyg ()
   
   getsubcmd=( apt-cyg --completion-get-subcommand $(echo "${COMP_LINE}" | sed -E 's/^[ \t]*[^ \t]+//g;s/[^ \t]+$//g') )
   subcmd="$( "${getsubcmd[@]}" )"
+  mirroridxopt=$(echo ${COMP_LINE} | awk 'BEGIN { RS=" " } /^-M|--mirror-index$/ { if(getline) printf "-M %s", $1 }')
   
   case "$subcmd" in
     install|depends|rdepends|describe|find|category)
-      COMPREPLY=( $(awk '/^@ /{print $2}' "$(apt-cyg pathof setup.ini)") )
+      COMPREPLY=( $(awk '/^@ /{print $2}' "$(apt-cyg pathof ${mirroridxopt} setup.ini)") )
       ;;
     remove)
       COMPREPLY=( $(apt-cyg --no-header show 2>/dev/null | awk '$0=$1') )
       ;;
     pathof)
-      COMPREPLY=( cache mirror mirrordir cache/mirrordir setup.ini )
+      COMPREPLY=( cache mirror mirrordir cache/mirrordir setup.ini lastmirror )
       ;;
     *)
       COMPREPLY=( "${__APT_CYG_SUBCMDS[@]}" )
@@ -1382,6 +1398,9 @@ function __apt-cyg ()
       ;;
     --proxy|-p)
       COMPREPLY=( auto inherit none http:// )
+      ;;
+    --mirror-index|-M)
+      COMPREPLY=( $(seq 0 $(($(apt-cyg pathof lastmirror | wc -w)-1))) )
       ;;
     *)
       COMPREPLY+=( "${__APT_CYG_OPTIONS[@]}" )
@@ -2281,6 +2300,11 @@ function parse_args ()
       
       --mirror|-m)
         OPT_MIRROR+=( "$2" )
+        shift 2 || break
+        ;;
+      
+      --mirror-index|-M)
+        OPT_MIRROR_INDEX="$2"
         shift 2 || break
         ;;
       


### PR DESCRIPTION
- Add --mirror-index|-M option.
- Add fd tweaks to findworkspace() and its caller for error handling for the above option.
- Add completion for the above option with new pathof argument.

## General note

It is the best way to implement to handle multiple mirrors correctly, but it is not a trivial task.
Currently, specifying mirrors overwrites `setup.rc`, so it is difficult to use it casually.
This is a compromised measure to choose a mirro from last-mirror list.

## Note for fd tweaks

`findworkspace()` handles mirror related information, so it is natural place to implement this feature.
On the other hand, it is not appropriate to handle user input because `apt-cyg-pathof()` suppresses `findworkspace()` output.
This suppression is also reasonable for characteristics of `apt-cyg-pathof()` as a utility function.

As comments in source, the solution of the problem in this patch is to add fd 3 bypass to the suppression.
This is not a straight soluation but works at least.

## Note for completion

* `lastmirror` is added to `pathof` argument choices for completion of argument of `--mirror-index|-M`. It might be overkill.
* `--mirror-index|-M <n>` in command line is passed to `apt-cyg pathof setup.ini` for package name completion.
