### PR TITLE
Improve `proxy-auto`.

### DIFF
--- a/apt-cyg
+++ b/apt-cyg
@@ -973,11 +973,12 @@ function proxy_auto ()
   
   [ -n "$OPT_PROXY_FORCE_REFRESH" ] && last=0
   if (( (now - ${last:-0}) < OPT_PROXY_REFRESH_INTERVAL )); then
-    proxy="$(<"$cache")"
+    read proxy < "$cache"
   else
-    proxy=$("${WGET[@]}" --no-proxy -q -O - wpad/wpad.dat \
-    | grep PROXY \
-    | sed -e 's/^.*PROXY\s*\([^"]*\).*$/http:\/\/\1/g')
+    read proxy < <(
+      "${WGET[@]}" --no-proxy -q -O - wpad/wpad.dat \
+      | sed -nE 's@//.*@@g;/PROXY/s@^.*PROXY\s*([^"; ]*).*$@http://\1@gp'
+    )
     echo "$proxy" > "$cache"
   fi
   [ -n "$proxy" ] && proxy_set "$proxy"


### PR DESCRIPTION
Proxy was not split correctly, if 'wpad.dat' has comment or SOCKS.

* Ignore comment of '// ...'.
* Only adopt the first proxy with `PROXY ...'.
   * Ignore after the first proxy.

This pull request is related to issue #112